### PR TITLE
Add perftest cli entry point

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,6 +11,7 @@ source = rics
 omit =
     src/rics/translation/dio/*
     src/rics/_internal*
+    src/rics/performance/cli.py
     src/rics/utility/plotting.py
     src/rics/utility/_just_the_way_i_like_it.py
     src/rics/translation/factory.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Entry point `rics-perf` for multivariate performance testing, taking candidates from `./candidates.py`
+  and test case data from `./test_data.py`.
+
 ### Changed
 - Performance testing figures updated; now shows best result as well.
 - Updated `MultiCaseTimer.EXPECTED_RUNTIME_WARNING_LIMIT`, added `MultiCaseTimer.EXPECTED_RUNTIME_ERROR_LIMIT`. The old

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,13 @@ classifiers = [
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/rsundqvist/rics/issues"
 
+[tool.poetry.scripts]
+rics-perf = "rics.performance.cli:_main"
+
 [tool.poetry.dependencies]
 python = "<3.11,>=3.8"
 
+click = "*"
 pandas = ">=1.1"
 
 # [tool.poetry.group.translation.dependencies]

--- a/src/rics/performance/_multi_case_timer.py
+++ b/src/rics/performance/_multi_case_timer.py
@@ -3,7 +3,6 @@ import warnings
 from timeit import Timer
 from typing import Any, Callable, Collection, Dict, List, Optional, Union
 
-from rics.performance._format_perf_counter import format_perf_counter
 from rics.performance._format_perf_counter import format_seconds as fmt_time
 from rics.utility.misc import tname
 
@@ -19,19 +18,12 @@ class MultiCaseTimer:
     Args:
         candidate_method: A single method, collection of method or a dict {label: function} of candidates.
         test_data: A single datum or a dict ``{label: data}`` to evaluate candidates on.
-        sanity_check: If ``True``, verify total expected runtime.
     """
-
-    EXPECTED_RUNTIME_WARNING_LIMIT = 4 * 60 * 60
-    """Warn of long runtimes above this limit (4 hours)."""
-    EXPECTED_RUNTIME_ERROR_LIMIT: int = 6 * EXPECTED_RUNTIME_WARNING_LIMIT
-    """Raise an exceptions above this limit (six times the ``EXPECTED_RUNTIME_WARNING_LIMIT``)."""
 
     def __init__(
         self,
         candidate_method: Union[CandFunc, Collection[CandFunc], Dict[str, CandFunc]],
         test_data: Union[Any, Dict[str, Any]],
-        sanity_check: bool = True,
     ) -> None:
         self._candidates = _process_candidates(candidate_method)
         if not self._candidates:  # pragma: no cover
@@ -40,7 +32,6 @@ class MultiCaseTimer:
         self._data = test_data if isinstance(test_data, dict) else _process_single_test_datum(test_data)
         if not self._data:  # pragma: no cover
             raise ValueError("No case data given.")
-        self._check = sanity_check
 
     def run(
         self,
@@ -75,15 +66,13 @@ class MultiCaseTimer:
         See Also:
             The :py:class:`timeit.Timer` class which this implementation depends on.
         """
-        per_candidate_number = self._compute_number_of_iterations(number, time_per_candidate)
-        if self._check and number is None:  # pragma: no cover
-            self._sanity_check(repeat, time_per_candidate, self.EXPECTED_RUNTIME_ERROR_LIMIT)
+        per_candidate_number = self._compute_number_of_iterations(number, repeat, time_per_candidate)
 
         run_results = {}
         for candidate_label, func in self._candidates.items():
             candidate_number = per_candidate_number[candidate_label]
             candidate_results: Dict[str, List[float]] = {}
-            LOGGER.info("Evaluate candidate '%s' %dx%d times...", candidate_label, repeat, candidate_number)
+            LOGGER.info("Evaluate candidate '%s' %dx%d times..", candidate_label, repeat, candidate_number)
             for data_label, test_data in self._data.items():
                 raw_timings = Timer(lambda: func(test_data)).repeat(repeat, candidate_number)  # noqa: B023
                 best, worst = min(raw_timings), max(raw_timings)
@@ -101,7 +90,7 @@ class MultiCaseTimer:
         return run_results
 
     def _compute_number_of_iterations(
-        self, number: Optional[int], time_allocation: float
+        self, number: Optional[int], repeat: int, time_allocation: float
     ) -> Dict[str, int]:  # pragma: no cover
         if isinstance(number, int):
             ans = {case: number for case in self._data}
@@ -113,28 +102,11 @@ class MultiCaseTimer:
                     for data in self._data.values():
                         candidate_func(data)  # noqa: B023
 
-                number, time_taken = Timer(_run_all).autorange()
-                ans[candidate_label] = max(2, int(number * time_allocation / time_taken))
+                auto_number, auto_time = Timer(_run_all).autorange()
+                candidate_number = int((time_allocation * auto_number) / (repeat * auto_time))
+                ans[candidate_label] = max(2, candidate_number)
 
         return ans
-
-    def _sanity_check(
-        self, repeat: int, time_allocation: float, max_expected_runtime: Optional[float]
-    ) -> None:  # pragma: no cover
-        expected_runtime = len(self._candidates) * repeat * time_allocation
-
-        ert_nice = format_perf_counter(0, expected_runtime)
-        if max_expected_runtime is not None and expected_runtime > self.EXPECTED_RUNTIME_WARNING_LIMIT:
-            warnings.warn(f"Long total expected runtime: {ert_nice}")
-
-        if max_expected_runtime is not None and expected_runtime > max_expected_runtime:
-            limit = format_perf_counter(0, max_expected_runtime)
-            raise ValueError(
-                f"Long expected runtime: {ert_nice} > limit={limit}. Increase 'max_expected_runtime' or"
-                " set it to None to allow."
-            )
-
-        LOGGER.info(f"Expected total runtime: {ert_nice}.")
 
 
 def _process_candidates(
@@ -150,5 +122,5 @@ def _process_candidates(
 
 def _process_single_test_datum(test_data: Any) -> Dict[str, Any]:  # pragma: no cover
     s = repr(test_data)
-    key = f"{s[:32]}..." if len(s) > 32 else s
-    return {f"Example: '{key}'": test_data}
+    key = f"{s[:29]}..." if len(s) > 32 else s
+    return {f"Sample data: '{key}'": test_data}

--- a/src/rics/performance/_multi_case_timer.py
+++ b/src/rics/performance/_multi_case_timer.py
@@ -34,8 +34,12 @@ class MultiCaseTimer:
         sanity_check: bool = True,
     ) -> None:
         self._candidates = _process_candidates(candidate_method)
+        if not self._candidates:  # pragma: no cover
+            raise ValueError("No candidates given.")
 
         self._data = test_data if isinstance(test_data, dict) else _process_single_test_datum(test_data)
+        if not self._data:  # pragma: no cover
+            raise ValueError("No case data given.")
         self._check = sanity_check
 
     def run(
@@ -79,7 +83,7 @@ class MultiCaseTimer:
         for candidate_label, func in self._candidates.items():
             candidate_number = per_candidate_number[candidate_label]
             candidate_results: Dict[str, List[float]] = {}
-            LOGGER.debug("Run candidate '%s' %dx%d times...", candidate_label, repeat, candidate_number)
+            LOGGER.info("Evaluate candidate '%s' %dx%d times...", candidate_label, repeat, candidate_number)
             for data_label, test_data in self._data.items():
                 raw_timings = Timer(lambda: func(test_data)).repeat(repeat, candidate_number)  # noqa: B023
                 best, worst = min(raw_timings), max(raw_timings)

--- a/src/rics/performance/_util.py
+++ b/src/rics/performance/_util.py
@@ -70,7 +70,9 @@ def plot_run(
     if y not in data:  # pragma: no cover
         raise ValueError(f"Bad {unit=}; column '{y}' not present in data.")
 
-    fig, (left, right) = plt.subplots(ncols=2, tight_layout=True, figsize=(14, 7), sharey=True)
+    fig, (left, right) = plt.subplots(
+        ncols=2, tight_layout=True, figsize=(8 + 4 * data.Candidate.nunique(), 7), sharey=True
+    )
     left.set_title("Average")
     right.set_title("Best")
     fig.suptitle("Performance", size=24)

--- a/src/rics/performance/_util.py
+++ b/src/rics/performance/_util.py
@@ -20,10 +20,10 @@ def to_dataframe(run_results: ResultsDict) -> pd.DataFrame:
             ans.append(
                 pd.DataFrame(
                     {
-                        "Time [s]": data_results,
-                        "Test data": data_label,
                         "Candidate": candidate_label,
+                        "Test data": data_label,
                         "Run no": range(len(data_results)),
+                        "Time [s]": data_results,
                     }
                 )
             )

--- a/src/rics/performance/cli.py
+++ b/src/rics/performance/cli.py
@@ -1,0 +1,151 @@
+"""Entry point for the performance testing CLI program."""
+import datetime
+
+import click
+
+from rics._internal_support.types import PathLikeType
+from rics.performance import run_multivariate_test as _run
+
+
+def run(
+    time_per_candidate: float = 2.0,
+    name: PathLikeType = "performance",
+    save_raw: bool = True,
+) -> None:
+    """Run a multivariate performance test.
+
+    Required files:
+        * candidates.py - Public functions are used as candidates.
+        * test_data.py - Members whose name start with `'case_'` are used as test case data.
+
+    Hint:
+       Define an ``ALL``-attribute to declare explicit members to use.
+
+    Args:
+        time_per_candidate: Time in seconds to allocate to each candidate function.
+        name: Name to use for artifacts produced. Also used as the figure title (stylized).
+        save_raw: If ``True``, write raw performance data to disk.
+
+    Raises:
+        ValueError: If ``candidates.py`` or ``test_data.py`` are missing or empty.
+    """
+    import inspect
+    import pathlib
+    import sys
+
+    import matplotlib.pyplot as plt
+
+    from rics.utility import configure_stuff
+
+    name = pathlib.Path(str(name))
+    pretty = name.stem.replace("-", " ").replace("_", " ").title()
+
+    print(f"{' Begin Performance Evaluation ':=^80}")
+    print(f"|  {f'  {repr(pretty)}  ':^74}  |")
+    print("-" * 80)
+
+    configure_stuff()
+    sys.path.insert(0, ".")
+
+    try:
+        import candidates as candidates_module  # type: ignore
+
+        candidates = (
+            candidates_module.ALL
+            if hasattr(candidates_module, "ALL")
+            else [func for name, func in inspect.getmembers(candidates_module, inspect.isfunction) if name[0] != "_"]
+        )
+    except ModuleNotFoundError:
+        raise ValueError("No file called 'candidates.py' in the current working directory.")
+
+    try:
+        import test_data as test_data_module  # type: ignore
+
+        test_data = (
+            test_data_module.ALL
+            if hasattr(test_data_module, "ALL")
+            else {
+                name[len("case_") :]: data
+                for name, data in inspect.getmembers(test_data_module)
+                if name.lower().startswith("case_")
+            }
+        )
+    except ModuleNotFoundError:
+        raise ValueError("No file called 'test_data.py' in the current working directory.")
+
+    now = datetime.datetime.now()
+    eta_str = (now + datetime.timedelta(seconds=len(candidates) * time_per_candidate)).strftime("%A %d, %H:%M:%S")
+    now_str = now.strftime("%Y-%m-%d %H:%M:%S")
+    print(f"{f'| Found {len(candidates)} candidates and {len(test_data)} data variants.':<78} |")
+    print(f"{f'| Started: {now_str}, ETA: {eta_str}':<78} |")
+    print("=" * 80)
+
+    try:
+        result = _run(candidates, test_data, time_per_candidate=time_per_candidate)
+    except ValueError as e:
+        if str(e).startswith("No candidates"):
+            raise ValueError(
+                "No candidate functions found. Candidates must be public, "
+                "or you must define the 'ALL'-attribute in 'candidates.py"
+            )
+        if str(e).startswith("No case"):
+            raise ValueError(
+                "No case data found. Case data attributes must start with 'case_', "
+                "or you must define the 'ALL'-attribute in 'test_data.py"
+            )
+        else:
+            raise e
+
+    best = result.groupby(["Candidate", "Test data"]).min()
+    best = best[filter(lambda s: "time" in s.lower(), best.columns)]
+    print(best)
+
+    fig = plt.gcf()
+    fig.suptitle(pretty)
+    figure_path = name.with_suffix(".png")
+    plt.savefig(figure_path)
+    print(f"Figure saved: '{figure_path}'")
+
+    if save_raw:
+        performance_report_path = name.with_suffix(".txt")
+        result.set_index(["Candidate", "Test data"]).to_string(performance_report_path)
+        print(f"Data saved: '{performance_report_path.absolute()}'")
+
+
+@click.command("Multivariate performance test")
+@click.option(
+    "--time-per-candidate",
+    help="Time in seconds to allocate to each candidate function.",
+    type=float,
+    default="2.0",
+    show_default=True,
+)
+@click.option(
+    "--name",
+    help="Name to use for artifacts produced. Also used as the figure title (stylized).",
+    type=click.Path(dir_okay=False, writable=True),
+    default="performance.png",
+    show_default=True,
+)
+@click.option(
+    "--save-raw/--no-save-raw",
+    help="If set, write raw performance data to disk.",
+    default=True,
+    is_flag=True,
+    show_default=True,
+)
+def _main(time_per_candidate: float, name: str, save_raw: bool) -> None:
+    """Run a multivariate performance test.
+
+    \b
+    Required files:
+        candidates.py - Public functions are used as candidates.
+        test_data.py - Members whose name start with 'case_' are used as case data.
+
+    Hint: Define an 'ALL'-attribute to declare explicit members to use.
+    """  # noqa: DAR101, D301
+    run(time_per_candidate, name, save_raw)
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
Sample usage:
```bash
(.venv) (base) dev@ubuntu:~/git/rics/cli-demo$ rics-perf --time-per-candidate=20 --name="sample-run"
========================= Begin Performance Evaluation =========================
|                                 'Sample Run'                                 |
--------------------------------------------------------------------------------
| Found 2 candidates and 2 data variants.                                      |
| Started: 2022-07-22 17:08:55, ETA: Friday 22, 17:09:35                       |
================================================================================
2022-07-22T17:08:55.502 [rics.performance:INFO] Evaluate candidate 'do_something' 5x19 times..
2022-07-22T17:09:14.896 [rics.performance:INFO] Evaluate candidate 'do_another_thing' 5x19 times..
                            Time [s]   Time [ms]      Time [μs]
Candidate        Test data                                     
do_another_thing 1_sec      0.101097  101.096963  101096.963474
                 5_sec      0.102906  102.906441  102906.441316
do_something     1_sec      0.101098  101.098358  101098.358421
                 5_sec      0.102419  102.418559  102418.559211
Figure saved: '/home/dev/cli-demo/sample-run.png'
Data saved: '/home/dev/cli-demo/sample-run.txt'
```

![sample-run](https://user-images.githubusercontent.com/7727900/180491355-4e032ebf-8594-4d48-b489-671b416d5d31.png)

Synopsis:
```bash
(.venv) (base) dev@ubuntu:~/git/rics$ rics-perf --help
Usage: rics-perf [OPTIONS]

  Run a multivariate performance test.

  Required files:
      candidates.py - Public functions are used as candidates.
      test_data.py - Members whose name start with 'case_' are used as case data.

  Hint: Define an 'ALL'-attribute to declare explicit members to use.

Options:
  --time-per-candidate FLOAT  Time in seconds to allocate to each candidate
                              function.  [default: 2.0]
  --name FILE                 Name to use for artifacts produced. Also used as
                              the figure title (stylized).  [default:
                              performance.png]
  --save-raw / --no-save-raw  If set, write raw performance data to disk.
                              [default: save-raw]
  --help                      Show this message and exit.
(.venv) (base) dev@ubuntu:~/git/rics$ 
```