### PR TITLE
Key and Index translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Translation of `pandas.Index` types.
 - The `translation.testing` module.
 - Experimental and hacky implementation of translation for nested sequences
 - Entry point `rics-perf` for multivariate performance testing, taking candidates from `./candidates.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Experimental and hacky implementation of translation for nested sequences
 - Entry point `rics-perf` for multivariate performance testing, taking candidates from `./candidates.py`
   and test case data from `./test_data.py`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and test case data from `./test_data.py`.
 
 ### Changed
+- Permit `Translator` instances to be created with explicit fetch data. Translations will be generated based on the 
+  inputs by using a `TestFetcher` instance. Functionality in this mode is limited.
 - Performance testing figures updated; now shows best result as well.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Performance testing figures updated; now shows best result as well.
 
 ### Removed
+- Dunder ``Mapper.__call__``
 - Expected runtime checks for perftests
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expected runtime checks for perftests
 
 ### Fixed
+- It is now possible to use one name per element when translating sequences
 - Perftest argument `time_per_candidate` now used correctly.
 - Filter out `NaN` values in `AbstractFetcher`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Cookbook recipes for translating dict keys and Pandas index types.
 - Translation of `pandas.Index` types.
 - The `translation.testing` module.
-- Experimental and hacky implementation of translation for nested sequences
+- Experimental and hacky implementation of translation for nested sequences.
 - Entry point `rics-perf` for multivariate performance testing, taking candidates from `./candidates.py`
   and test case data from `./test_data.py`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- The `translation.testing` module.
 - Experimental and hacky implementation of translation for nested sequences
 - Entry point `rics-perf` for multivariate performance testing, taking candidates from `./candidates.py`
   and test case data from `./test_data.py`.

--- a/docs/documentation/cookbook/index.rst
+++ b/docs/documentation/cookbook/index.rst
@@ -7,3 +7,4 @@ Random stuff that I've had enough use for to want to save. Not really related to
    :glob:
 
    ./*
+   ../examples/notebooks/cookbook/*

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx==5.0.2
 myst-parser==0.18.0
 nbsphinx==0.8.9
 pydata-sphinx-theme==0.9.0
+ipython==8.4.0

--- a/jupyterlab/demo/cookbook/translation.ipynb
+++ b/jupyterlab/demo/cookbook/translation.ipynb
@@ -1,0 +1,405 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "93a678fb-4a20-4598-80cf-80d269c07d7f",
+   "metadata": {},
+   "source": [
+    "# Translation\n",
+    "A dummy fetcher that generates translation data is used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "62173765-876a-4531-b099-2e78e7b81700",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-07-23T14:43:42.276850Z",
+     "iopub.status.busy": "2022-07-23T14:43:42.276544Z",
+     "iopub.status.idle": "2022-07-23T14:43:46.004558Z",
+     "shell.execute_reply": "2022-07-23T14:43:46.003154Z",
+     "shell.execute_reply.started": "2022-07-23T14:43:42.276789Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/dev/git/rics/src/rics/translation/_translator.py:156: UserWarning: No fetcher given. Translation data will be automatically generated.\n",
+      "  warnings.warn(\"No fetcher given. Translation data will be automatically generated.\", UserWarning)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from rics.translation import Translator\n",
+    "\n",
+    "NAMES_TO_TRANSLATE = \"name\"\n",
+    "translate = Translator(fmt=\"{x}, {y}\").translate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16700ef6-8cb7-49e4-97c0-7e666d6b93e6",
+   "metadata": {},
+   "source": [
+    "## Translating `dict` keys\n",
+    "\n",
+    "When translating using `inplace=False` (the default), the `Translator` will always try to return an object of the same type. \n",
+    "The `Translator` doesn't know what to do with the `dict_keys` class, so we wrap the values we want to translate using a known type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bdce0756-5865-47ca-980d-ccc2af9a92ea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-07-23T14:43:46.008175Z",
+     "iopub.status.busy": "2022-07-23T14:43:46.007747Z",
+     "iopub.status.idle": "2022-07-23T14:43:46.029658Z",
+     "shell.execute_reply": "2022-07-23T14:43:46.027378Z",
+     "shell.execute_reply.started": "2022-07-23T14:43:46.008151Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'k0': 0, 'k1': 1, 'k2': 2, 'k3': 3}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'x-of-k0, y-of-k0': 0,\n",
+       " 'x-of-k1, y-of-k1': 1,\n",
+       " 'x-of-k2, y-of-k2': 2,\n",
+       " 'x-of-k3, y-of-k3': 3}"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a_dict = {f\"k{i}\": i for i in range(4)}\n",
+    "print(a_dict)\n",
+    "\n",
+    "translated_keys = translate(list(a_dict), names=NAMES_TO_TRANSLATE)\n",
+    "{\n",
+    "    tk: a_dict[k] for  # tk is translated\n",
+    "    k, tk in zip(a_dict, translated_keys)\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "589afe77-fc51-40a6-9b33-15d5812b53e7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-07-23T14:02:24.050457Z",
+     "iopub.status.busy": "2022-07-23T14:02:24.050140Z",
+     "iopub.status.idle": "2022-07-23T14:02:24.060245Z",
+     "shell.execute_reply": "2022-07-23T14:02:24.058355Z",
+     "shell.execute_reply.started": "2022-07-23T14:02:24.050431Z"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Translating Pandas `index` and `columns`\n",
+    "Recipies for translating involving `pandas` types. The only special case here is the `Index` type, which is immutable and thus cannot be translated inplace. We'll use some wrapper methods for this instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "aad0654a-a565-4fe3-9dab-ff7aece08c2c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-07-23T14:43:46.031122Z",
+     "iopub.status.busy": "2022-07-23T14:43:46.030818Z",
+     "iopub.status.idle": "2022-07-23T14:43:46.039453Z",
+     "shell.execute_reply": "2022-07-23T14:43:46.038131Z",
+     "shell.execute_reply.started": "2022-07-23T14:43:46.031098Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from typing import Union\n",
+    "\n",
+    "\n",
+    "def translate_index(data: Union[pd.Series, pd.DataFrame]) -> None:\n",
+    "    \"\"\"Translate the index of a pandas ``Series`` or ``DataFrame``.\"\"\"\n",
+    "    data.index = translate(data.index)\n",
+    "\n",
+    "\n",
+    "def translate_columns(data: pd.DataFrame) -> None:\n",
+    "    \"\"\"Translate the columns of a pandas ``DataFrame``.\"\"\"\n",
+    "    data.columns = translate(data.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "243bf95c-6dbf-4fff-9f16-82b51e235670",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-07-23T14:43:46.041930Z",
+     "iopub.status.busy": "2022-07-23T14:43:46.041617Z",
+     "iopub.status.idle": "2022-07-23T14:43:46.073557Z",
+     "shell.execute_reply": "2022-07-23T14:43:46.069377Z",
+     "shell.execute_reply.started": "2022-07-23T14:43:46.041905Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>col0</th>\n",
+       "      <th>col1</th>\n",
+       "      <th>col2</th>\n",
+       "      <th>col3</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>name</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>idx0</th>\n",
+       "      <td>00</td>\n",
+       "      <td>01</td>\n",
+       "      <td>02</td>\n",
+       "      <td>03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>idx1</th>\n",
+       "      <td>10</td>\n",
+       "      <td>11</td>\n",
+       "      <td>12</td>\n",
+       "      <td>13</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>idx2</th>\n",
+       "      <td>20</td>\n",
+       "      <td>21</td>\n",
+       "      <td>22</td>\n",
+       "      <td>23</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     col0 col1 col2 col3\n",
+       "name                    \n",
+       "idx0   00   01   02   03\n",
+       "idx1   10   11   12   13\n",
+       "idx2   20   21   22   23"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.DataFrame(\n",
+    "    data=[[\"00\", \"01\", \"02\", \"03\"], [\"10\", \"11\", \"12\", \"13\"], [\"20\", \"21\", \"22\", \"23\"]],\n",
+    "    columns=[f\"col{i}\" for i in range(4)],\n",
+    "    index=[f\"idx{i}\" for i in range(3)],\n",
+    ")\n",
+    "df.index.name = NAMES_TO_TRANSLATE\n",
+    "s = df.col0\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "32dfe8f0-3ccb-4424-9f4b-12deacbe5a05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-07-23T14:43:46.075189Z",
+     "iopub.status.busy": "2022-07-23T14:43:46.074871Z",
+     "iopub.status.idle": "2022-07-23T14:43:46.109778Z",
+     "shell.execute_reply": "2022-07-23T14:43:46.108704Z",
+     "shell.execute_reply.started": "2022-07-23T14:43:46.075166Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>x-of-col0, y-of-col0</th>\n",
+       "      <th>x-of-col1, y-of-col1</th>\n",
+       "      <th>x-of-col2, y-of-col2</th>\n",
+       "      <th>x-of-col3, y-of-col3</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>x-of-idx0, y-of-idx0</th>\n",
+       "      <td>x-of-00, y-of-00</td>\n",
+       "      <td>x-of-01, y-of-01</td>\n",
+       "      <td>x-of-02, y-of-02</td>\n",
+       "      <td>x-of-03, y-of-03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>x-of-idx1, y-of-idx1</th>\n",
+       "      <td>x-of-10, y-of-10</td>\n",
+       "      <td>x-of-11, y-of-11</td>\n",
+       "      <td>x-of-12, y-of-12</td>\n",
+       "      <td>x-of-13, y-of-13</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>x-of-idx2, y-of-idx2</th>\n",
+       "      <td>x-of-20, y-of-20</td>\n",
+       "      <td>x-of-21, y-of-21</td>\n",
+       "      <td>x-of-22, y-of-22</td>\n",
+       "      <td>x-of-23, y-of-23</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     x-of-col0, y-of-col0 x-of-col1, y-of-col1  \\\n",
+       "x-of-idx0, y-of-idx0     x-of-00, y-of-00     x-of-01, y-of-01   \n",
+       "x-of-idx1, y-of-idx1     x-of-10, y-of-10     x-of-11, y-of-11   \n",
+       "x-of-idx2, y-of-idx2     x-of-20, y-of-20     x-of-21, y-of-21   \n",
+       "\n",
+       "                     x-of-col2, y-of-col2 x-of-col3, y-of-col3  \n",
+       "x-of-idx0, y-of-idx0     x-of-02, y-of-02     x-of-03, y-of-03  \n",
+       "x-of-idx1, y-of-idx1     x-of-12, y-of-12     x-of-13, y-of-13  \n",
+       "x-of-idx2, y-of-idx2     x-of-22, y-of-22     x-of-23, y-of-23  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "translate_index(df)\n",
+    "translate_columns(df)\n",
+    "translate(df, inplace=True)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a490bc87-871a-4040-9b98-0e7b230786ad",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-07-23T14:43:46.112094Z",
+     "iopub.status.busy": "2022-07-23T14:43:46.111001Z",
+     "iopub.status.idle": "2022-07-23T14:43:46.126722Z",
+     "shell.execute_reply": "2022-07-23T14:43:46.125758Z",
+     "shell.execute_reply.started": "2022-07-23T14:43:46.112061Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "x-of-idx0, y-of-idx0    x-of-00, y-of-00\n",
+       "x-of-idx1, y-of-idx1    x-of-10, y-of-10\n",
+       "x-of-idx2, y-of-idx2    x-of-20, y-of-20\n",
+       "Name: col0, dtype: object"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "translate_index(s)\n",
+    "translate(s, inplace=True)\n",
+    "s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0aa90a13-584b-4e74-b679-704dae7338a7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,9 @@ flake8-docstrings = ["-D102"]  # Docstrings are inherited
 [tool.flakeheaven.exceptions."src/rics/mapping/score_functions.py"]
 flake8-darglint = ["-DAR101", "-DAR301"]
 
+[tool.flakeheaven.exceptions."src/rics/translation/testing.py"]
+flake8-docstrings = ["-DAR101", "-D102"]
+
 [tool.flakeheaven.exceptions."tests/"]
 # Test modules/classes/functions are never "really" public, and I don't want to typehint/document all of them :).
 flake8-bandit = ["-S101", "-S301", "-S403"]

--- a/src/rics/mapping/_directional_mapping.py
+++ b/src/rics/mapping/_directional_mapping.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Generic, Hashable, Iterable, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, Generic, Hashable, Iterable, Mapping, Optional, Tuple, TypeVar
 
 from rics.mapping._cardinality import Cardinality
 from rics.mapping.exceptions import CardinalityError
@@ -27,8 +27,8 @@ class DirectionalMapping(Generic[HL, HR]):
     def __init__(
         self,
         cardinality: Cardinality.ParseType = None,
-        left_to_right: LeftToRight[HL, HR] = None,
-        right_to_left: RightToLeft[HR, HL] = None,
+        left_to_right: Mapping[HL, Iterable[HR]] = None,
+        right_to_left: Mapping[HR, Iterable[HL]] = None,
         _verify: bool = True,
     ) -> None:
         self._left_to_right = self._to_other(left_to_right, right_to_left)
@@ -130,9 +130,9 @@ class DirectionalMapping(Generic[HL, HR]):
     @classmethod
     def _to_other(
         cls,
-        primary_side: Optional[Union[LeftToRight, RightToLeft]],
-        backup_side: Optional[Union[LeftToRight, RightToLeft]],
-    ) -> Union[LeftToRight, RightToLeft]:
+        primary_side,  # noqa: ANN001
+        backup_side,  # noqa: ANN001
+    ):  # noqa: ANN206
         if primary_side is not None:
             return primary_side
 
@@ -148,19 +148,6 @@ class DirectionalMapping(Generic[HL, HR]):
         return {k: tuple(set(m)) for k, m in other_side.items()}
 
     def _select(self, elements: Iterable[HAnySide], left: bool, exclude: bool) -> "DirectionalMapping":
-        """Perform a selection on left-side elements.
-
-        Args:
-            elements: Elements to select.
-            left: If ``True``, select elements from the left side.
-            exclude: If ``True``, return everything **except** the given elements.
-
-        Returns:
-            A new instance for the selection.
-
-        Raises:
-            KeyError: If any of the chosen elements do not exist and ``exclude=False``.
-        """
         items = self._left_to_right if left else self._right_to_left
 
         if not exclude:

--- a/src/rics/mapping/_mapper.py
+++ b/src/rics/mapping/_mapper.py
@@ -130,8 +130,6 @@ class Mapper(Generic[ValueType, CandidateType, ContextType]):
             _verify=True,
         )
 
-    __call__ = apply
-
     @property
     def unmapped_values_action(self) -> ActionLevel:
         """Return the action to take if mapping fails for any values."""

--- a/src/rics/translation/_translator.py
+++ b/src/rics/translation/_translator.py
@@ -658,7 +658,9 @@ class Translator(Generic[Translatable, NameType, SourceType, IdType]):
                     return cls._dont_ruin_string(attr() if callable(attr) else attr)
 
         raise AttributeError(
-            "Must pass 'names' since type " f"'{type(translatable)}' has none of {_NAME_ATTRIBUTES} as and attribute."
+            "Must pass 'names' since no valid name could be found for data of type "
+            f"'{tname(translatable)}'."
+            f" Attributes checked: {_NAME_ATTRIBUTES}."
         )
 
     @classmethod

--- a/src/rics/translation/_translator.py
+++ b/src/rics/translation/_translator.py
@@ -346,10 +346,10 @@ class Translator(Generic[Translatable, NameType, SourceType, IdType]):
                 return res
 
         if override_function is None:
-            name_to_source = self.mapper(names_to_translate, sources)
+            name_to_source = self.mapper.apply(names_to_translate, sources)
         else:
             try:
-                name_to_source = self.mapper(names_to_translate, sources, override_function=func)
+                name_to_source = self.mapper.apply(names_to_translate, sources, override_function=func)
             except UserMappingError as e:
                 raise UnknownSourceError(e.value, e.candidates) from e
 

--- a/src/rics/translation/dio/_pandas.py
+++ b/src/rics/translation/dio/_pandas.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Sequence, TypeVar
 import pandas as pd
 
 from rics.translation.dio._data_structure_io import DataStructureIO
-from rics.translation.dio._sequence import translate_sequence
+from rics.translation.dio._sequence import translate_sequence, verify_names
 from rics.translation.offline import TranslationMap
 from rics.translation.types import IdType, NameType
 
@@ -22,7 +22,7 @@ class PandasIO(DataStructureIO):
         if isinstance(translatable, pd.DataFrame):
             return translatable[names].to_dict(orient="list")
         else:
-            return {names[0]: translatable}
+            return {names[0]: translatable} if len(names) == 1 else {k: [v] for k, v in translatable.to_dict()}
 
     @staticmethod
     def insert(translatable: T, names: List[NameType], tmap: TranslationMap, copy: bool) -> Optional[T]:
@@ -32,6 +32,7 @@ class PandasIO(DataStructureIO):
             for name in names:
                 translatable[name] = translatable[name].map(tmap[name].get)
         else:
+            verify_names(len(translatable), names)
             translatable.update(pd.Series(translate_sequence(translatable, names, tmap), index=translatable.index))
 
         return translatable if copy else None

--- a/src/rics/translation/dio/_resolve.py
+++ b/src/rics/translation/dio/_resolve.py
@@ -21,7 +21,7 @@ def resolve_io(arg: Translatable) -> Type[DataStructureIO]:
     Raises:
         UntranslatableTypeError: If not IO could be found.
     """
-    for tio_class in (PandasIO, DictIO, SequenceIO, SingleValueIO):
+    for tio_class in DictIO, PandasIO, SequenceIO, SingleValueIO:
         if tio_class.handles_type(arg):
             return tio_class
 

--- a/src/rics/translation/dio/_sequence.py
+++ b/src/rics/translation/dio/_sequence.py
@@ -19,13 +19,12 @@ class SequenceIO(DataStructureIO):
 
     @staticmethod
     def extract(translatable: T, names: List[NameType]) -> Dict[NameType, Sequence[IdType]]:
-        if len(names) != 1:
-            raise ValueError("Length of names must be one.")
-
-        return {names[0]: list(translatable)}
+        verify_names(len(translatable), names)
+        return {names[0]: list(translatable)} if len(names) == 1 else {n: list(r) for n, r in zip(names, translatable)}
 
     @staticmethod
     def insert(translatable: T, names: List[NameType], tmap: TranslationMap, copy: bool) -> Optional[T]:
+        verify_names(len(translatable), names)
         t = translate_sequence(translatable, names, tmap)
 
         if copy:
@@ -41,12 +40,14 @@ class SequenceIO(DataStructureIO):
 
 def translate_sequence(s: T, names: List[NameType], tmap: TranslationMap) -> List[Optional[str]]:
     """Return a translated copy of the sequence `s`."""
-    if len(names) == 1:
-        return list(map(tmap[names[0]].get, s))
-    elif len(names) == len(s):
-        return [tmap[n].get(idx) for n, idx in zip(names, s)]
-    else:
+    return list(map(tmap[names[0]].get, s)) if len(names) == 1 else [tmap[n].get(idx) for n, idx in zip(names, s)]
+
+
+def verify_names(data_len: int, names: List[NameType]) -> None:
+    """Verify that the length of names is either 1 or equal to the length of the data."""
+    num_names = len(names)
+    if num_names != 1 and num_names != data_len:
         raise ValueError(
-            f"Number of names {len(names)} must be one or equal to the length of the data {len(s)} to "
+            f"Number of names {len(names)} must be 1 or equal to the length of the data ({data_len}) to "
             f"translate, but got {names=}."
         )

--- a/src/rics/translation/dio/_sequence.py
+++ b/src/rics/translation/dio/_sequence.py
@@ -40,7 +40,15 @@ class SequenceIO(DataStructureIO):
 
 def translate_sequence(s: T, names: List[NameType], tmap: TranslationMap) -> List[Optional[str]]:
     """Return a translated copy of the sequence `s`."""
-    return list(map(tmap[names[0]].get, s)) if len(names) == 1 else [tmap[n].get(idx) for n, idx in zip(names, s)]
+    if len(names) == 1:
+        return list(map(tmap[names[0]].get, s))
+
+    return [
+        translate_sequence(element, [name], tmap)  # type: ignore
+        if SequenceIO.handles_type(element)
+        else tmap[name].get(element)
+        for name, element in zip(names, s)
+    ]
 
 
 def verify_names(data_len: int, names: List[NameType]) -> None:

--- a/src/rics/translation/fetching/_abstract_fetcher.py
+++ b/src/rics/translation/fetching/_abstract_fetcher.py
@@ -74,7 +74,7 @@ class AbstractFetcher(Fetcher[SourceType, IdType]):
         candidates = set(self.get_placeholders(source) if candidates is None else candidates)
         placeholders = set(placeholders).difference(ans)  # Don't remap cached mappings
 
-        for actual, wanted in self.mapper(placeholders, candidates, context=source).left_to_right.items():
+        for actual, wanted in self.mapper.apply(placeholders, candidates, context=source).left_to_right.items():
             ans[actual] = wanted[0]
 
         for not_mapped in placeholders.difference(ans):

--- a/src/rics/translation/testing.py
+++ b/src/rics/translation/testing.py
@@ -1,0 +1,93 @@
+"""Test implementations."""
+from typing import Any, Collection, Dict, Iterable, List, Tuple
+
+import pandas as pd
+
+from rics.mapping import DirectionalMapping as _DirectionalMapping
+from rics.mapping import Mapper as _Mapper
+from rics.mapping.types import ContextType, UserOverrideFunction, ValueType
+from rics.translation.fetching import Fetcher as _Fetcher
+from rics.translation.fetching.types import IdsToFetch as _IdsToFetch
+from rics.translation.offline.types import PlaceholderTranslations as _PlaceholderTranslations
+from rics.translation.offline.types import SourcePlaceholderTranslations as _SourcePlaceholderTranslations
+from rics.translation.types import IdType, SourceType
+
+
+class TestMapper(_Mapper[ValueType, ValueType, ContextType]):
+    """Dummy ``Mapper`` implementation."""
+
+    def apply(
+        self,
+        values: Iterable[ValueType],
+        candidates: Iterable[ValueType],
+        context: ContextType = None,
+        override_function: UserOverrideFunction = None,
+        **kwargs: Any,
+    ) -> _DirectionalMapping[ValueType, ValueType]:
+        """Map values to themselves, unless `override_function` is given."""
+        values = set(values)
+
+        left_to_right: Dict[ValueType, Tuple[ValueType, ...]] = {v: (v,) for v in values}
+
+        if override_function:
+            candidates = set(candidates)
+            for v in values:
+                user_override = override_function(v, candidates, context)
+                if user_override is not None:
+                    left_to_right[v] = (user_override,)
+
+        return _DirectionalMapping(left_to_right=left_to_right)
+
+
+class TestFetcher(_Fetcher[SourceType, IdType]):
+    """Dummy ``Fetcher`` implementation.
+
+    A "happy path" fetcher implementation for testing purposes. Returns generated names for all IDs and placeholders,
+    so translation retrieval will never fail when using this fetcher.
+    """
+
+    def __init__(self, sources: Collection[SourceType] = None) -> None:
+        self._sources = set(sources or [])
+
+    @property
+    def allow_fetch_all(self) -> bool:
+        return False  # pragma: no cover
+
+    @property
+    def online(self) -> bool:
+        return True  # pragma: no cover
+
+    @property
+    def sources(self) -> List[SourceType]:
+        return list(self._sources)
+
+    @property
+    def placeholders(self) -> Dict[SourceType, List[str]]:
+        raise NotImplementedError
+
+    def fetch(
+        self,
+        ids_to_fetch: Iterable[_IdsToFetch[SourceType, IdType]],
+        placeholders: Iterable[str] = (),
+        required: Iterable[str] = (),
+    ) -> _SourcePlaceholderTranslations:
+        """Return generated translations for all IDs and placeholders."""
+        return {itf.source: self._generate_data(itf, list(placeholders)) for itf in ids_to_fetch}
+
+    @staticmethod
+    def _generate_data(itf: _IdsToFetch, placeholders: List[str]) -> _PlaceholderTranslations[SourceType]:
+        if itf.ids is None:
+            raise NotImplementedError
+
+        ids = list(itf.ids)
+        df = pd.DataFrame([[f"{p}-of-{idx}" for p in placeholders] for idx in ids], columns=placeholders)
+        df["id"] = ids
+        return _PlaceholderTranslations.make(itf.source, df)
+
+    def fetch_all(
+        self, placeholders: Iterable[str] = (), required: Iterable[str] = ()
+    ) -> _SourcePlaceholderTranslations[SourceType]:
+        raise NotImplementedError
+
+    def __repr__(self) -> str:
+        return f"TestFetcher(sources={repr(self._sources or None)})"

--- a/src/rics/translation/types.py
+++ b/src/rics/translation/types.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Callable, Dict, Hashable, Iterable, List, Opti
 if TYPE_CHECKING:
     import pandas  # noqa: F401
 
-Translatable = TypeVar("Translatable", "pandas.DataFrame", "pandas.Series", Dict, Sequence, str, int)
+Translatable = TypeVar("Translatable", "pandas.DataFrame", "pandas.Index", "pandas.Series", Dict, Sequence, str, int)
 """Enumeration of translatable types."""
 
 ID: str = "id"

--- a/tests/mapping/test_mapper.py
+++ b/tests/mapping/test_mapper.py
@@ -16,31 +16,31 @@ def candidates():
 
 def test_default(candidates):
     mapper = Mapper()
-    assert mapper(candidates, ["a"]).left_to_right == {"a": ("a",)}
-    assert mapper(candidates, ["b"]).left_to_right == {"b": ("b",)}
-    assert mapper(candidates, ["a", "b"]).left_to_right == {"a": ("a",), "b": ("b",)}
+    assert mapper.apply(candidates, ["a"]).left_to_right == {"a": ("a",)}
+    assert mapper.apply(candidates, ["b"]).left_to_right == {"b": ("b",)}
+    assert mapper.apply(candidates, ["a", "b"]).left_to_right == {"a": ("a",), "b": ("b",)}
 
 
 def test_with_overrides(candidates):
     mapper = Mapper(overrides={"a": "fixed"})
-    assert mapper(["a"], candidates).left_to_right == {"a": ("fixed",)}
-    assert mapper(["b"], candidates).left_to_right == {"b": ("b",)}
-    assert mapper(["a", "b"], candidates).left_to_right == {"a": ("fixed",), "b": ("b",)}
+    assert mapper.apply(["a"], candidates).left_to_right == {"a": ("fixed",)}
+    assert mapper.apply(["b"], candidates).left_to_right == {"b": ("b",)}
+    assert mapper.apply(["a", "b"], candidates).left_to_right == {"a": ("fixed",), "b": ("b",)}
 
 
 def test_user_override(candidates):
     mapper = Mapper(overrides={"a": "fixed"}, unknown_user_override_action="ignore")
-    assert mapper(["a"], candidates, override_function=lambda *args: "ab").left_to_right == {"a": ("ab",)}
-    assert mapper(["a"], candidates, override_function=lambda *args: "ignored").left_to_right == {"a": ("fixed",)}
-    assert mapper(["a"], candidates, override_function=lambda *args: None).left_to_right == {"a": ("fixed",)}
+    assert mapper.apply(["a"], candidates, override_function=lambda *args: "ab").left_to_right == {"a": ("ab",)}
+    assert mapper.apply(["a"], candidates, override_function=lambda *args: "ignored").left_to_right == {"a": ("fixed",)}
+    assert mapper.apply(["a"], candidates, override_function=lambda *args: None).left_to_right == {"a": ("fixed",)}
 
     mapper = Mapper(overrides={"a": "fixed"}, unknown_user_override_action="warn")
     with pytest.warns(UserMappingWarning):
-        assert mapper(["a"], candidates, override_function=lambda *args: "bad").left_to_right == {"a": ("fixed",)}
+        assert mapper.apply(["a"], candidates, override_function=lambda *args: "bad").left_to_right == {"a": ("fixed",)}
 
     mapper = Mapper(overrides={"a": "fixed"}, unknown_user_override_action="raise")
     with pytest.raises(UserMappingError):
-        mapper(["a"], candidates, override_function=lambda *args: "bad")
+        mapper.apply(["a"], candidates, override_function=lambda *args: "bad")
 
 
 @pytest.mark.parametrize(
@@ -60,7 +60,7 @@ def test_multiple_matches(values, expected, allow_multiple, candidates):
         score_function=_substring_score,
         cardinality=None if allow_multiple else Cardinality.OneToOne,
     )
-    assert mapper(values, candidates).left_to_right == expected
+    assert mapper.apply(values, candidates).left_to_right == expected
 
 
 @pytest.mark.parametrize(
@@ -81,7 +81,7 @@ def test_multiple_matches_with_overrides(values, expected, allow_multiple, candi
         score_function=_substring_score,
         cardinality=None if allow_multiple else Cardinality.OneToOne,
     )
-    assert mapper(values, candidates).left_to_right == expected
+    assert mapper.apply(values, candidates).left_to_right == expected
 
 
 def test_mapping_failure(candidates):
@@ -129,5 +129,5 @@ def test_filter(filters, expected, candidates):
         cardinality=Cardinality.ManyToMany,  # Anything goes
     )
 
-    actual = mapper("abc", candidates).left_to_right
+    actual = mapper.apply("abc", candidates).left_to_right
     assert actual == expected

--- a/tests/translation/dio/test_insert.py
+++ b/tests/translation/dio/test_insert.py
@@ -10,7 +10,7 @@ from .conftest import TRANSLATED, UNTRANSLATED
 NAME = "nconst"
 
 
-@pytest.mark.parametrize("ttype", [list, tuple, pd.Series, np.array])
+@pytest.mark.parametrize("ttype", [list, tuple, pd.Index, pd.Series, np.array])
 def test_insert(ttype, translation_map):
     actual, ans = _do_insert(translation_map, ttype, copy=True)
     _test_eq(ans, ttype(TRANSLATED[NAME]))
@@ -50,7 +50,7 @@ def _do_insert(translation_map, ttype, copy):
 
 
 def _test_eq(actual, expected):
-    if isinstance(actual, (pd.Series, np.ndarray)):
-        assert all(actual == expected)
-    else:
+    try:
         assert actual == expected
+    except ValueError:
+        assert all(actual == expected)


### PR DESCRIPTION
Fixes #83 

## Proposed Changes

- Add cookbook recipes for keys and indices
- Add support for translating `pandas.Index`
- Allow `Translator` instances to be created with a fecther for testing purposes
