### PR TITLE
Allow names to be inherited when translating attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for translating an attribute of `translatable` in `Translator.translate`.
+  - Names may be inherited from the parent (ie a pandas `Index` may inherit the name of the series)
 - Cookbook recipes for translating dict keys and Pandas index types.
 - Translation of `pandas.Index` types.
 - The `translation.testing` module.

--- a/tests/translation/conftest.py
+++ b/tests/translation/conftest.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple
 
 import pytest
 
@@ -54,20 +54,20 @@ class HexFetcher(AbstractFetcher[str, int]):
 
 
 @pytest.fixture(scope="session")
-def hex_fetcher():
+def hex_fetcher() -> Generator[HexFetcher, None, None]:
     yield HexFetcher()
 
 
 @pytest.fixture(scope="session")
-def translator(hex_fetcher):
+def translator(hex_fetcher) -> Generator[Translator, None, None]:
     yield Translator(hex_fetcher, fmt="{id}:{hex}[, positive={positive}]")
 
 
 @pytest.fixture(scope="session")
-def imdb_translator():
+def imdb_translator() -> Generator[Translator, None, None]:
     yield Translator.from_config("tests/translation/config.imdb.toml")
 
 
 @pytest.fixture(scope="module")
-def translation_map(imdb_translator):
+def translation_map(imdb_translator) -> Generator[Translator, None, None]:
     yield imdb_translator.store({"firstTitle": [], "nconst": []}).cache

--- a/tests/translation/test_translator.py
+++ b/tests/translation/test_translator.py
@@ -392,3 +392,14 @@ def test_translate_attribute():
     translate(df, attribute="index")
 
     assert df.index.tolist() == translate(list(range(3)), names=df.index.name)
+
+
+def test_inherited_name(translator):
+    assert translator._allow_name_inheritance
+    s = pd.Series([1, 1, 2, 2, 2, 3, 4], name="positive_numbers")
+
+    translator.translate(s, attribute="index")
+
+    s.name = None
+    with pytest.raises(AttributeError):
+        translator.translate(s, attribute="index")


### PR DESCRIPTION
Useful eg for value counts:

```python
translator = Translator(allow_name_inheritance=True)  # This is the default
s = pd.Series([1, 1, 2, 3], name="numbers")
translate(s.value_counts(), attribute="index")
```
The index created by `value_counts` is `None` by default.