### PR TITLE
Replace regex-based Format solution (fix #52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Improve handling for optional `Format` blocks (#52). Nested optional blocks are *not* supported.
+
 ## [0.15.0] - 2022-08-01
 
 ### Added

--- a/src/rics/translation/offline/parse_format_string.py
+++ b/src/rics/translation/offline/parse_format_string.py
@@ -1,0 +1,190 @@
+"""Utility module for parsing raw ``Format`` input strings."""
+
+from dataclasses import dataclass as _dataclass
+from string import Formatter as _Formatter
+from typing import List, List as _List
+
+OPTIONAL_BLOCK_START_DELIMITER = "["
+OPTIONAL_BLOCK_END_DELIMITER = "]"
+OPTIONAL_BLOCK_DELIMITER_ESCAPED = "\\"
+
+_formatter = _Formatter()
+_hint = "Hint: Use '\\' to escape '[' and ']', e.g. '\\[', to use angle brackets as regular characters."
+
+
+class MalformedOptionalBlockError(ValueError):
+    """Error raised for improper optional blocks."""
+
+    @staticmethod
+    def get_marker_row(format_string: str, i: int = -1, open_position: int = -1) -> str:
+        """Get a string of length equal to `format_string` which marks problem locations."""
+        markers = [" "] * len(format_string)
+
+        if i != -1:
+            markers[i] = "^"
+        if open_position != -1:
+            markers[open_position] = "^"
+        return "".join(markers)
+
+
+class UnusedOptionalBlockError(MalformedOptionalBlockError):
+    """Errors raised when optional blocks do not use any placeholders."""
+
+    def __init__(self, format_string: str, i: int, open_position: int) -> None:
+        problem_locations = MalformedOptionalBlockError.get_marker_row(format_string, i, open_position)
+        super().__init__(
+            f"""Malformed optional block. No {{placeholders}} found in range {open_position, i}).
+'{format_string}'
+ {problem_locations}
+{_hint}""".strip()
+        )
+
+
+class BadDelimiterError(MalformedOptionalBlockError):
+    """Errors raised due to mismatched delimiters."""
+
+    def __init__(self, format_string: str, i: int, open_position: int) -> None:
+        problem_locations = MalformedOptionalBlockError.get_marker_row(format_string, i, open_position)
+
+        if i == -1:
+            super().__init__(
+                f"""Malformed optional block. Optional block opened at i={open_position} was never closed.
+'{format_string}'
+ {problem_locations}""".strip()
+            )
+        else:
+            info = (
+                "there is no block to close"
+                if open_position == -1
+                else f"nested optional blocks are not supported (opened at {open_position})"
+            )
+
+            super().__init__(
+                f"""Malformed optional block. Got '{format_string[i]}' at {i=}, but {info}.
+    '{format_string}'
+     {problem_locations}
+{_hint}""".strip()
+            )
+
+
+@_dataclass(frozen=True)
+class Element:
+    """Information about a single block in a ``Format`` specification."""
+
+    part: str
+    """String literal."""
+    placeholders: _List[str]
+    """Placeholder names in `part`, if any."""
+    required: bool
+    """Flag indicating whether the element may be excluded."""
+
+    @property
+    def positional_part(self) -> str:
+        """Return a positional version of the `part` attribute."""
+        if not self.placeholders:
+            return self.part
+
+        return self.part.format(**{p: "{}" for p in self.placeholders})
+
+    @staticmethod
+    def make(s: str, in_optional_block: bool) -> "Element":
+        """Create an ``Element`` from an input string `s`.
+
+        Args:
+            s: Input data.
+            in_optional_block: Flag indicating whether `s` was found inside an optional block.
+
+        Returns:
+            A new ``Element``.
+        """
+        parsed_block = s.replace("\\[", "[").replace("\\]", "]")
+        placeholders = [x[1] for x in _formatter.parse(parsed_block) if x[1]]
+
+        return Element(
+            parsed_block,
+            placeholders,
+            not (placeholders and in_optional_block),
+        )
+
+
+def verify_delimiters(format_string: str) -> None:
+    """Verify that optional blocks are properly formatted.
+
+    Args:
+        format_string: User input string.
+
+    Raises:
+        BadDelimiterError: For unbalanced optional block delimitation characters.
+    """
+    open_position = -1
+
+    for i in range(len(format_string)):
+        if not _is_delimiter(format_string, i):
+            continue
+
+        char = format_string[i]
+
+        if char == OPTIONAL_BLOCK_START_DELIMITER:
+            if open_position != -1:
+                raise BadDelimiterError(format_string, i, open_position)
+            open_position = i
+        else:
+            if open_position == -1:
+                raise BadDelimiterError(format_string, i, -1)
+            open_position = -1
+
+    if open_position != -1:
+        raise BadDelimiterError(format_string, -1, open_position)
+
+
+def get_elements(format_string: str) -> List[Element]:
+    """Split a format string into elements.
+
+    Args:
+        format_string: User input string.
+
+    Returns:
+        A list of parsed elements.
+
+    Raises:
+        BadDelimiterError: For unbalanced optional block delimitation characters.
+        UnusedOptionalBlockError: If optional blocks are defined without placeholders.
+    """
+    if not format_string:
+        return [Element("", [], required=True)]
+
+    verify_delimiters(format_string)
+
+    delimiter_idx = [i for i in range(1, len(format_string)) if _is_delimiter(format_string, i)]
+
+    delimiter_idx.append(len(format_string))
+
+    ans: _List[Element] = []
+    in_optional_block = _is_delimiter(format_string, 0)
+    prev_idx = int(in_optional_block)
+    for idx in delimiter_idx:
+        if prev_idx != idx:
+            element = Element.make(format_string[prev_idx:idx], in_optional_block)
+
+            if in_optional_block and not element.placeholders:
+                raise UnusedOptionalBlockError(format_string, idx, prev_idx - 1)
+
+            ans.append(element)
+
+        prev_idx = idx + 1
+        in_optional_block = not in_optional_block
+
+    return ans
+
+
+def _is_delimiter(s: str, i: int) -> bool:
+    char = s[i]
+
+    if char not in (
+        OPTIONAL_BLOCK_START_DELIMITER,
+        OPTIONAL_BLOCK_END_DELIMITER,
+    ):
+        return False
+
+    escaped = i > 0 and s[i - 1] == OPTIONAL_BLOCK_DELIMITER_ESCAPED
+    return not escaped

--- a/tests/translation/offline/test_format.py
+++ b/tests/translation/offline/test_format.py
@@ -9,20 +9,6 @@ def fmt():
 
 
 @pytest.mark.parametrize(
-    "fmt, expected_parts",
-    [
-        ("!{id}:[:{code}<]:{name}<", ["!", "{id}", ":", ":{code}<", ":", "{name}", "<"]),
-        ("!{id}:[:{code}<][:{name}<]<", ["!", "{id}", ":", ":{code}<", ":{name}<", "<"]),
-        ("!><{id}:[:{code}<][:{name}]", ["!><", "{id}", ":", ":{code}<", ":{name}"]),
-        ("{id}:[:{code}]:{name}", ["{id}", ":", ":{code}", ":", "{name}"]),
-    ],
-)
-def test_parse(fmt, expected_parts):
-    parts = [e.part for e in Format._parse_format_string(fmt)]
-    assert parts == expected_parts
-
-
-@pytest.mark.parametrize(
     "placeholders, expected",
     [
         (("id", "code", "name"), "{id}::{code}:{name}"),
@@ -49,7 +35,6 @@ def test_missing_required(fmt):
         fmt.fstring(("does", "not", "exist"))
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "kwargs, expected",
     [
@@ -58,6 +43,15 @@ def test_missing_required(fmt):
     ],
 )
 def test_nested(kwargs, expected):
-    fmt = Format("{{{id}}} is required[, '{optional}' is [optional]!]")
+    fmt = Format("{{{id}}} is required[, '{optional}' is \\[optional\\]!]")
     fstring = fmt.fstring(kwargs)
     assert fstring.format(**kwargs) == expected
+
+
+def test_multiple_optional_placeholders():
+    fmt = Format("{required}[ opt0={opt0}, opt1={opt1}]")
+
+    assert fmt.fstring(["required"]) == "{required}"
+    assert fmt.fstring(["required", "opt0"]) == "{required}"
+    assert fmt.fstring(["required", "opt1"]) == "{required}"
+    assert fmt.fstring(["required", "opt0", "opt1"]) == "{required} opt0={opt0}, opt1={opt1}"

--- a/tests/translation/offline/test_parse_format_string.py
+++ b/tests/translation/offline/test_parse_format_string.py
@@ -1,0 +1,82 @@
+import pytest as pytest
+
+from rics.translation.offline.parse_format_string import (
+    BadDelimiterError,
+    Element,
+    UnusedOptionalBlockError,
+    get_elements,
+)
+
+
+@pytest.mark.parametrize(
+    "s, expected",
+    [
+        (
+            "static",
+            [
+                Element(part="static", placeholders=[], required=True),
+            ],
+        ),
+        (
+            "{id}",
+            [
+                Element(part="{id}", placeholders=["id"], required=True),
+            ],
+        ),
+        (
+            "[{optional-id}] \\[literal-angle-brackets\\]",
+            [
+                Element(part="{optional-id}", placeholders=["optional-id"], required=False),
+                Element(part=" [literal-angle-brackets]", placeholders=[], required=True),
+            ],
+        ),
+        (
+            "{id} \\[literal-angle-brackets\\]",
+            [
+                Element(part="{id} [literal-angle-brackets]", placeholders=["id"], required=True),
+            ],
+        ),
+        (
+            "!{id}:[:{code}<]:{name}<",
+            [
+                Element(part="!{id}:", placeholders=["id"], required=True),
+                Element(part=":{code}<", placeholders=["code"], required=False),
+                Element(part=":{name}<", placeholders=["name"], required=True),
+            ],
+        ),
+        (
+            "{id}:{first_name}[ '{nickname}'][, age {age}].",
+            [
+                Element(part="{id}:{first_name}", placeholders=["id", "first_name"], required=True),
+                Element(part=" '{nickname}'", placeholders=["nickname"], required=False),
+                Element(part=", age {age}", placeholders=["age"], required=False),
+                Element(part=".", placeholders=[], required=True),
+            ],
+        ),
+    ],
+)
+def test_get_elements(s, expected):
+    assert get_elements(s) == expected
+
+
+@pytest.mark.parametrize(
+    "s, i, already_open",
+    [
+        ("]", 0, False),
+        ("[[", 1, True),
+        ("[{a}] ]", 6, False),
+    ],
+)
+def test_improper_brackets(s, i, already_open):
+    with pytest.raises(BadDelimiterError, match=f"{i=}.*{'' if already_open else ''}"):
+        get_elements(s)
+
+
+def test_unterminated_block():
+    with pytest.raises(BadDelimiterError, match="opened at i=2.*never closed"):
+        get_elements("  [  ")
+
+
+def test_optional_block_without_placeholders():
+    with pytest.raises(UnusedOptionalBlockError, match="(1, 6)"):
+        get_elements(" [aaaa] ")


### PR DESCRIPTION
Replace the old `Format` regex with a linear-time implementation in the `translation.offline.parse_format_string` module.

Improvements:
- Properly handle placeholders defined in optional blocks.
- Clarify usage of optional blocks
- Clarify limitations.