### PR TITLE
Mapper stability improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Make `Mapper.compute_scores` and `apply` respect the iteration order of its arguments when there are match conflicts.
 - Improve messaging when translation is aborted due to mapping failure.
 
 ## [0.16.1] - 2022-09-23

--- a/docs/documentation/mapping-primer.rst
+++ b/docs/documentation/mapping-primer.rst
@@ -9,6 +9,9 @@ when using the :meth:`Mapper.apply <rics.mapping.Mapper.apply>`-function, though
 
 Scoring procedure
 -----------------
+The ``Mapper`` first applies :ref:`Overrides and filtering`, after which the actual :ref:`Score computations` are
+performed.
+
 .. |caption| raw:: html
 
   <p style="text-align:right; font-style: italic;">Colours mapped by <br> spectral distance (RGB).</p>
@@ -19,61 +22,82 @@ Scoring procedure
 
    |caption|
 
-The steps presented here is the *hierarchical* order. It does not necessarily represent the actual order in which things
-are computed.
+Overrides and filtering
+~~~~~~~~~~~~~~~~~~~~~~~
+Overrides and filtering adhere to a strict hierarchy (the one presented below). Overrides take precedence over filters,
+and runtime overrides takes precedence over static overrides.
 
-1. Runtime overrides (type: :attr:`~rics.mapping.types.UserOverrideFunction`); set ``score = ∞`` for the desired
-   match , and ``score = -∞`` for others [#f1]_.
+1. Runtime overrides (type: :attr:`~rics.mapping.types.UserOverrideFunction`); set ``score=∞`` for the chosen candidate,
+   and ``score=-∞`` for others.
 
-2. Static overrides (type: ``dict`` or :attr:`~rics.utility.collections.dicts.InheritedKeysDict`); set ``score = ∞``
-   for the desired match, and ``score = -∞`` for others [#f1]_.
+2. Static overrides (type: ``dict`` or :attr:`~rics.utility.collections.dicts.InheritedKeysDict`); set ``score=∞`` for
+   the chosen candidate, and ``score=-∞`` for others.
 
-3. Filtering (type: :attr:`~rics.mapping.types.FilterFunction`); set ``score = -∞`` for undesirable matches only.
+3. Filtering (type: :attr:`~rics.mapping.types.FilterFunction`); set ``score=-∞`` for undesirable matches only.
 
-4. If there are any Heuristics (type: :class:`~rics.mapping._heuristic_score.HeuristicScore`), apply..
+Score computations
+~~~~~~~~~~~~~~~~~~
+4. Compute value-candidate match scores (type: :attr:`~rics.mapping.types.ScoreFunction`). Higher is better.
+
+5. If there are any Heuristics (type: :class:`~rics.mapping._heuristic_score.HeuristicScore`), apply..
 
     a. Short-circuiting (type: :attr:`~rics.mapping.types.FilterFunction`); reinterpret a ``FilterFunction`` such that
-       the returned candidates (if any) are treated as overrides [#f1]_.
+       the returned candidates (if any) are treated as overrides.
 
     b. Aliasing (type: :attr:`~rics.mapping.types.AliasFunction`); try to improve ``ScoreFunction`` accuracy by
        applying heuristics to the ``(value, candidates)``-argument pairs.
 
     c. Finally, select the best score at each stage (from no to all heuristics) for each pair.
 
-5. Regular score (type: :attr:`~rics.mapping.types.ScoreFunction`); higher is better.
-
-The final output of the scoring procedure is a score matrix (a pandas ``DataFrame``), where columns are candidates and
-values make up the index.
+The final output is a score matrix (type: :class:`pandas.DataFrame`), where columns are candidates and values make up
+the index.
 
 .. csv-table:: Partial mapping scores for the :ref:`dvdrental` example.
    :file: dvdrental-scores.csv
    :header-rows: 1
    :stub-columns: 1
 
-The full score matrix has over 100 values (rows). The table above contains a subset of 20. The ``'rental_date'`` value
-can be seen having only negative-infinity matching scores. This is intentional; the database has no suitable table for
-translating dates. Mapping would've most likely failed regardless, but explicitly stating that ``'rental_date'`` should
-not be translated (by using a filter) is more efficient. More importantly, it is also clearer.
+The ``'rental_date'``-value can be seen having only negative-infinity matching scores due to filtering. Mapping would've
+likely failed for this value regardless, but using explicit filters clearly indicates that translation is not wanted.
 
 Matching procedure
 ------------------
 Given precomputed match scores (see the section above), make as many matches as possible given a ``Cardinality``
 restriction. These may be summarized as:
 
-* :attr:`~rics.mapping.Cardinality.OneToOne` = *'1:1'*. Each value and candidate may be used at most once.
+* :attr:`~rics.mapping.Cardinality.OneToOne` = *'1:1'*: Each value and candidate may be used at most once.
 * :attr:`~rics.mapping.Cardinality.OneToMany` = *'1:N'*: Values have exclusive ownership of matched candidate(s).
 * :attr:`~rics.mapping.Cardinality.ManyToOne` = *'N:1'*: Ensure that as many values as possible are *unambiguously*
   mapped (i.e. to a single candidate). This is the **default option** for new ``Mapper`` instances.
 * :attr:`~rics.mapping.Cardinality.ManyToMany` = *'M:N'*: All matches above the score limit are kept.
 
 In theory, ``OneToMany`` and ``ManyToOne`` are equally restrictive. During mapping however, the goal is usually to
-**find matches for the values**, not candidates. With that in mind, the ordering above may considered strictly decreasing
+find **matches for values**, not candidates. With that in mind, the ordering above may considered strictly decreasing
 in preciseness.
+
+Conflict resolution
+~~~~~~~~~~~~~~~~~~~
+When a single match out of multiple viable options must be chosen due to cardinality restrictions, priority is
+determined by the iteration order of `values` and `candidates`. The first value will prefer the first candidate, and so
+on. This logic does `not` consider future matches.
+
+>>> mapper = Mapper(cardinality='1:1', score_function=lambda value, *_: [1, 0] if value == 'v1' else [1, 1])
+>>> mapper.compute_scores(['v0', 'v1'], ['c0', 'c1'])
+candidates   c0   c1
+values
+v0          1.0  1.0
+v1          0.0  1.0
+>>> mapper.apply(['v0', 'v1'], ['c0', 'c1']).flatten()
+{'val0': 'cand0'}
+
+Notice that `val1` was left without a match, even though it could've been assigned to `cand0` if the equally viable
+matching `val0 → cand1` had been chosen first.
 
 Troubleshooting
 ---------------
 Unmapped values are allowed by default. If mapping failure is not an acceptable outcome for your application, initialize
-the ``Mapper`` with ``unmapped_values_action='raise'`` to ensure that an error is raised for unmapped values.
+the ``Mapper`` with ``unmapped_values_action='raise'`` to ensure that an error is raised for unmapped values, along with
+more detailed log messages which are emitted on the error level.
 
 Mapper ``.details``-messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -84,22 +108,17 @@ Records from these loggers are always emitted on the debug-level.
 .. code-block:: python
     :caption: The ``'rics.mapping.Mapper.accept.details'``-logger lists matches that were rejected in favour of the current match.
 
-    rics.mapping.Mapper.accept: Accepted: 'b' -> 'b'; score=1.000 >= 0.1.
-    rics.mapping.Mapper.accept.details: This match supersedes 4 other matches:
-      'b' -> 'ab'; score=0.500 (superseded on value='b').
-      'b' -> 'a'; score=0.000 < 0.1 (below threshold).
-      'b' -> 'fixed'; score=0.000 < 0.1 (below threshold).
-      'a' -> 'b'; score=-inf (superseded by short-circuit or override).
-    rics.mapping.Mapper: Match selection with cardinality='OneToOne' completed in 0.00369605 sec.
+    rics.mapping.Mapper.accept: Accepted: 'v0' -> 'c0'; score=1.000 >= 1.0.
+    rics.mapping.Mapper.accept.details: This match supersedes 2 other matches:
+        'v0' -> 'c1'; score=1.000 (superseded on value='v0').
+        'v1' -> 'c0'; score=1.000 (superseded on candidate='c0').
 
 .. code-block:: python
    :caption: The ``'rics.mapping.Mapper.unmapped.details'``-logger explains why values were left unmapped.
 
-    rics.mapping.Mapper.unmapped.details: Could not map value='is_nice':
-      'is_nice' -> 'name'; score=0.125 < 1.0 (below threshold).
-      'is_nice' -> 'gender'; score=0.083 < 1.0 (below threshold).
-      'is_nice' -> 'id'; score=0.000 < 1.0 (below threshold).
-    rics.mapping.Mapper.unmapped: Could not map {'is_nice'} in context='humans' to any of candidates={'name', 'gender', 'id'}.
+    rics.mapping.Mapper.unmapped.details: Could not map value='v1':
+        'v1' -> 'c0'; score=1.000 (superseded on candidate='c0': 'v0' -> 'c0'; score=1.000).
+        'v1' -> 'c1'; score=0.000 < 1.0 (below threshold).
 
 Unlike the ``unmapped.details``-logger, the level of the records emitted by its parent (the ``unmapped``-logger) is
 determined by the :attr:`Mapper.unmapped_values_action <rics.mapping.Mapper.unmapped_values_action>`-attribute (
@@ -136,6 +155,3 @@ To permanently enable verbose logging, initialize with ``enable_verbose_logging=
    ``enable_verbose_logging`` is not recommended.
 
 .. rubric:: Footnotes
-
-.. [#f1] Exactly how other scores are adjusted depends on cardinality. The last override applied takes priority when
-         conflicting overrides are defined.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ flake8-docstrings = ["-DAR101", "-D102"]
 flake8-bandit = ["-S101", "-S301", "-S403"]
 flake8-docstrings = ["-D100", "-D101", "-D102", "-D103"]
 flake8-darglint = ["-DAR101"]
-flake8-annotations = ["-ANN001", "-ANN101", "-ANN102", "-ANN201", "-ANN202", "-ANN204"]
+flake8-annotations = ["-ANN001", "-ANN101", "-ANN102", "-ANN201", "-ANN202", "-ANN204", "-ANN205", "-ANN206"]
 
 [tool.flakeheaven.exceptions."jupyterlab/"]
 flake8-annotations = ["-*"]

--- a/tests/mapping/test_mapper_hierarchy.py
+++ b/tests/mapping/test_mapper_hierarchy.py
@@ -1,0 +1,137 @@
+from itertools import product
+
+import pytest
+
+from rics.mapping import Cardinality, HeuristicScore, Mapper
+
+POSSIBLE_NUMBER_OF_LEGS = [0, 2, 3, 4]
+NUMBER_OF_LEGS = {
+    "cat": 4,
+    "dog": 4,
+    "three-legged cat": 3,
+    "human": 2,
+    "snake": 0,
+}
+
+CASES = list(
+    product(
+        Cardinality,
+        product([False, True], repeat=4),
+    )
+)
+
+
+def make_id(case):
+    cardinality, (override_function, static_override, filters, short_circuit) = case
+
+    x = f"{override_function=},{static_override=},{filters=},{short_circuit=}".split(",")
+    x = " | ".join([s.split("=")[0] for s in filter(lambda s: s.endswith("True"), x)])
+    x = x or "baseline"
+    return f"{cardinality.name}: <{x}>"
+
+
+@pytest.mark.parametrize("cardinality, run_params", CASES, ids=map(make_id, CASES))
+def test_hierarchy(cardinality, run_params):
+    run(cardinality, *run_params)
+
+
+def run(
+    cardinality,
+    use_override_function,
+    use_static_override,
+    use_filter,
+    use_short_circuit,
+):
+    values = NUMBER_OF_LEGS.copy()
+    actual = (
+        Mapper(
+            HeuristicScore(
+                score_function=lambda v, c, cxt: [float(c == NUMBER_OF_LEGS[v]) for c in c],
+                heuristics=[ShortCircuit.dogs_have_4_legs] if use_short_circuit else (),
+            ),
+            overrides=StaticOverride.nobody_gets_any_legs if use_static_override else None,
+            filter_functions=[(FilterFunction.nobody_has_4_legs, {})] if use_filter else (),
+            cardinality=cardinality,
+        )
+        .apply(
+            values=values,
+            candidates=POSSIBLE_NUMBER_OF_LEGS,
+            override_function=OverrideFunction.humans_have_4_legs if use_override_function else None,
+        )
+        .left_to_right
+    )
+
+    if use_override_function:
+        for animal, legs in OverrideFunction.expected(cardinality).items():
+            assert actual.pop(animal, legs) == legs, f"OverrideFunction: {animal=}"
+
+    if use_static_override:
+        for animal, legs in StaticOverride.expected(cardinality).items():
+            assert actual.pop(animal, legs) == legs, f"StaticOverride: {animal=}"
+
+    if use_filter:
+        for animal, legs in FilterFunction.expected(cardinality).items():
+            assert actual.pop(animal, legs) == legs, f"FilterFunction: {animal=}"
+
+    if use_short_circuit:
+        for animal, legs in ShortCircuit.expected(cardinality).items():
+            assert actual.pop(animal, legs) == legs, f"ShortCircuit: {animal=}"
+
+    for animal, legs in Baseline.expected(cardinality).items():
+        assert actual.pop(animal, legs) == legs, f"Baseline: {animal=}"
+
+    assert not actual, "This isn't supposed to happen!"
+
+
+class Baseline:
+    @classmethod
+    def expected(cls, cardinality):
+        number_of_legs = NUMBER_OF_LEGS.copy()
+        if cardinality.one_left:
+            del number_of_legs["dog"]
+        return {v: (n,) for v, n in number_of_legs.items()}
+
+    @classmethod
+    def error(cls, cardinality):
+        return f"{cls.__name__}: {cardinality=}"
+
+
+class ShortCircuit:
+    @staticmethod
+    def dogs_have_4_legs(v, c, cxt):
+        return {4} if v == "dog" else set()
+
+    @classmethod
+    def expected(cls, cardinality):
+        # Cat usually has higher prio (first in iteration order), which is the main difference from the baseline.
+        return {"dog": (4,)}
+
+
+class FilterFunction:
+    @staticmethod
+    def nobody_has_4_legs(v, c, cxt):
+        ans = set(c)
+        ans.discard(4)
+        return ans
+
+    @classmethod
+    def expected(cls, cardinality):
+        return Baseline.expected(cardinality)
+
+
+class StaticOverride:
+    nobody_gets_any_legs = {animal: 0 for animal in NUMBER_OF_LEGS}
+
+    @classmethod
+    def expected(cls, cardinality):
+        return {a: (0,) for a in NUMBER_OF_LEGS}
+
+
+class OverrideFunction:
+    @staticmethod
+    def humans_have_4_legs(v, c, cxt):
+        return 4 if "human" in v else None
+
+    @classmethod
+    def expected(cls, cardinality):
+        return {"human": (4,)}

--- a/tests/performance/test_wrapper.py
+++ b/tests/performance/test_wrapper.py
@@ -11,16 +11,16 @@ def test_run_multivariate_test():
     ans = run_multivariate_test(
         candidate_method={
             "sleep": lambda t: sleep(t),
-            "sleep_x5": lambda t: sleep(t * 5),
+            "sleep_x4": lambda t: sleep(t * 4),
         },
         test_data={
-            "5 ms": 0.0050,
-            "7.5 ms": 0.0075,
+            "1 ms": 0.001,
+            "3 ms": 0.003,
         },
         time_per_candidate=0.1,
     )
-    assert sorted(ans["Candidate"].unique()) == ["sleep", "sleep_x5"]
-    assert sorted(ans["Test data"].unique()) == ["5 ms", "7.5 ms"]
+    assert sorted(ans["Candidate"].unique()) == ["sleep", "sleep_x4"]
+    assert sorted(ans["Test data"].unique()) == ["1 ms", "3 ms"]
 
     best = ans.groupby(["Candidate", "Test data"])["Time [ms]"].min()
-    assert (best["sleep"] < best["sleep_x5"]).all()
+    assert (best["sleep"] < best["sleep_x4"]).all()

--- a/tests/performance/test_wrapper.py
+++ b/tests/performance/test_wrapper.py
@@ -5,6 +5,7 @@ import pytest
 from rics.performance import run_multivariate_test
 
 
+@pytest.mark.xfail(strict=False)  # TODO: This test is flaky, especially on MacOS. Should not rely on sleep.
 @pytest.mark.filterwarnings("ignore:Matplotlib is currently using agg:UserWarning")
 @pytest.mark.filterwarnings("ignore:The test results may be unreliable:UserWarning")
 def test_run_multivariate_test():


### PR DESCRIPTION
General stability and test coverage improvements.

## Proposed Changes

- The mapping procedure now respects input order of `values` and `candidates` when one of several possible equal-score matches must be chosen due to cardinality restrictions. This used to be arbitrary based on `set` iteration order.
- Update mapping primer to reflect the above
