### PR TITLE
time_split: Add `step` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New `step` argument to `rics.ml.time_split` splitting functions.
+
 ## [3.1.0] - 2023-10-13
 
 ### Added

--- a/examples/time_split/plot_example_5.py
+++ b/examples/time_split/plot_example_5.py
@@ -1,0 +1,28 @@
+"""
+Fold sampling using the ``step``-argument.
+==========================================
+
+Filtering every other Thursday, preferring later folds.
+"""
+import pandas
+
+from rics import configure_stuff
+from rics.ml.time_split import log_split_progress, plot, split
+
+configure_stuff(format="[%(name)s:%(levelname)s] %(message)s")
+
+data = pandas.date_range("2022-01", "2022-03")
+config = kwargs = dict(schedule="0 0 * * THU", after="5d", step=2, n_splits=3, available=data)
+
+plot(**config, bar_labels="h", show_removed=True)
+# %%
+# Specifying a `step` is useful especially when working with non-stationary but slow-moving distributions. The `step`
+# argument will never reduce the number of folds below 1. The `n_splits` argument sets the `upper limit` on the number
+# of folds created; fewer folds may be produced, depending on the outer range of the available data.
+
+for fold in log_split_progress(split(**config), logger="my-logger"):
+    print("Doing work..")
+
+# %%
+# You may also use cron directly to filter a weekday based on the date. For example, ``'0 0 * * THU#2'`` will select the
+# second Thursday of every month.

--- a/src/rics/ml/time_split/_backend/_limits.py
+++ b/src/rics/ml/time_split/_backend/_limits.py
@@ -2,6 +2,7 @@ from typing import Iterable, List, NamedTuple, Optional, Tuple, Union
 
 from pandas import Timedelta, Timestamp
 
+from .._docstrings import docs
 from ..settings import auto_flex as settings
 from ..types import Flex, TimedeltaTypes
 
@@ -15,35 +16,15 @@ class _TimedeltaTuple(NamedTuple):
     tolerance: Timedelta
 
 
-def expand_limits(limits: LimitsTuple, *, flex: Union[Flex, LevelTuple, Iterable[LevelTuple]]) -> LimitsTuple:
+@docs
+def expand_limits(limits: LimitsTuple, *, flex: Union[Flex, LevelTuple, Iterable[LevelTuple]] = "auto") -> LimitsTuple:
     """Derive the `"real"` bounds of `limits`.
-
-    .. list-table:: Flex options.
-       :header-rows: 1
-       :widths: 20 80
-
-       * - Type
-         - Description
-       * - ``True`` or ``'auto'``
-         - Auto-flex using :attr:`auto_flex <rics.ml.time_split.settings.auto_flex>`-settings.
-       * - ``False``
-         - Do nothing; return `limits` unchanged.
-       * - ``str``
-         - A string `round_to` or `round_to<tolerance`, where `round_to` is the desired frequency of the `limits` and
-           `tolerance` is the maximum amount by which to change the input limits.
-       * - ``list[tuple]``
-         - Passing tuples ``(start_at, round_to, tolerance)`` will use the largest tuple such that
-           ``start_at > >= limits[1] - limits[0]``. Other parameters are interpreted as above.
-       * - ``tuple``
-         - Like ``list[tuple]``, but with just one level.
-
-    .. note::
-
-       Passing ``flex=[auto_flex.day, auto_flex.hour]`` is equivalent to ``flex='auto'``.
 
     Args:
         limits: A tuple ``(lo, hi)`` of timestamps.
-        flex: See the table above.
+        flex: Flex arguments as described in the {USER_GUIDE}. Also supports level-tuples
+            ``[(start_at, round_to, tolerance)...]``. Passing ``flex=[settings.auto_flex.day, settings.auto_flex.hour]``
+            is equivalent to ``flex='auto'``.
 
     Returns:
         Limits rounded according to the `flex`-argument.
@@ -65,7 +46,7 @@ def expand_limits(limits: LimitsTuple, *, flex: Union[Flex, LevelTuple, Iterable
         >>> expand_limits(limits, flex="d<1h")
         (Timestamp('2019-05-11 00:00:00'), Timestamp('2019-05-11 22:05:30'))
 
-        Limits will never be rounded in the "wrong" direction..
+        Limits will never be rounded in the "wrong" direction...
 
         >>> limits = Timestamp("2019-05-11"), Timestamp("2019-05-11 11:05:30")
         >>> expand_limits(limits, flex="d")

--- a/src/rics/ml/time_split/_docstrings.py
+++ b/src/rics/ml/time_split/_docstrings.py
@@ -24,6 +24,7 @@ _DOCSTRINGS = {
     "schedule": f"A collection of timestamps, a {_OFFSET}, or a cron expression.",
     "before": _SPAN.format(arg="before"),
     "after": _SPAN.format(arg="after"),
+    "step": "Select a subset of folds, preferring folds later in the schedule.",
     "n_splits": "Maximum number of folds, preferring folds later in the schedule.",
     "available": "Binds `schedule` to a range.",
     "flex": f'A {_OFFSET} used to expand `available` data to its likely `"true"` limits. Set to ``False`` to disable. '

--- a/src/rics/ml/time_split/_docstrings.py
+++ b/src/rics/ml/time_split/_docstrings.py
@@ -27,8 +27,9 @@ _DOCSTRINGS = {
     "step": "Select a subset of folds, preferring folds later in the schedule.",
     "n_splits": "Maximum number of folds, preferring folds later in the schedule.",
     "available": "Binds `schedule` to a range.",
-    "flex": f'A {_OFFSET} used to expand `available` data to its likely `"true"` limits. Set to ``False`` to disable. '
-    "See :attr:`types.Flex <rics.ml.time_split.types.Flex>` for details.",
-    "USER_GUIDE": "For more information about the `schedule` and `before/after`-arguments, see the :ref:`User guide`.",
+    "flex": f'A {_OFFSET} used to expand `available` data to its likely `"true"` limits. Pass ``False`` to disable.',
+    "USER_GUIDE": (
+        "For more information about the `schedule`, `before/after` and `flex`-arguments" ", see the :ref:`User guide`."
+    ),
     "OFFSET": _OFFSET,
 }

--- a/src/rics/ml/time_split/_frontend/_plot.py
+++ b/src/rics/ml/time_split/_frontend/_plot.py
@@ -65,7 +65,10 @@ def plot(
     row_count_bin: Union[str, pd.Series] = None,
     ax: "Axes" = None,
 ) -> "Axes":
-    """Visualize ranges in `splits`.
+    """Fold visualization.
+
+    This function plots the folds and in-fold splits that would be made by passing the same arguments to the
+    :func:`.split`-function.
 
     Args:
         schedule: {schedule}

--- a/src/rics/ml/time_split/_frontend/_split.py
+++ b/src/rics/ml/time_split/_frontend/_split.py
@@ -11,6 +11,7 @@ def split(
     *,
     before: Span = "7d",
     after: Span = 1,
+    step: int = 1,
     n_splits: Optional[int] = None,
     available: DatetimeIterable = None,
     flex: Flex = "auto",
@@ -21,6 +22,7 @@ def split(
         schedule: {schedule}
         before: {before}
         after: {after}
+        step: {step}
         n_splits: {n_splits}
         available: {available} Passing a tuple ``(min, max)`` is enough.
         flex: {flex}
@@ -34,6 +36,7 @@ def split(
         schedule,
         before=before,
         after=after,
+        step=step,
         n_splits=n_splits,
         flex=flex,
     ).get_splits(available)

--- a/src/rics/ml/time_split/_frontend/_split.py
+++ b/src/rics/ml/time_split/_frontend/_split.py
@@ -18,6 +18,8 @@ def split(
 ) -> DatetimeSplits:
     """Create time-based cross-validation splits.
 
+    To visualize the folds, pass the same arguments to the :func:`.plot`-function.
+
     Args:
         schedule: {schedule}
         before: {before}

--- a/src/rics/ml/time_split/integration/pandas/_impl.py
+++ b/src/rics/ml/time_split/integration/pandas/_impl.py
@@ -56,6 +56,7 @@ def split_pandas(
     after: Span = 1,
     n_splits: Optional[int] = None,
     flex: Flex = "auto",
+    step: int = 1,
     time_column: Hashable = None,
     inclusive: Inclusive = "left",
     log_progress: LogProgressArg = False,
@@ -70,6 +71,7 @@ def split_pandas(
         schedule: {schedule}
         before: {before}
         after: {after}
+        step: {step}
         n_splits: {n_splits}
         flex: {flex}
         time_column: A column in `data` to split on. Use index if ``None``.
@@ -87,7 +89,14 @@ def split_pandas(
     """
     time = _verify_time_type(data, time_column)
 
-    splits = DatetimeIndexSplitter(schedule, before, after=after, n_splits=n_splits, flex=flex).get_splits(time)
+    splits = DatetimeIndexSplitter(
+        schedule,
+        before=before,
+        after=after,
+        step=step,
+        n_splits=n_splits,
+        flex=flex,
+    ).get_splits(time)
     tracked_splits = handle_log_progress_arg(log_progress, splits=splits)
 
     indexer = _Indexer(data, time=time, inclusive=inclusive)

--- a/src/rics/ml/time_split/integration/sklearn/_impl.py
+++ b/src/rics/ml/time_split/integration/sklearn/_impl.py
@@ -38,6 +38,7 @@ class ScikitLearnSplitter(BaseCrossValidator):  # type: ignore[misc]
         schedule: {schedule}
         before: {before}
         after: {after}
+        step: {step}
         n_splits: {n_splits}
         flex: {flex}
         log_progress: {log_progress}
@@ -54,11 +55,19 @@ class ScikitLearnSplitter(BaseCrossValidator):  # type: ignore[misc]
         after: Span = 1,
         n_splits: Optional[int] = None,
         flex: Flex = "auto",
+        step: int = 1,
         log_progress: LogProgressArg = False,
         verify_xy: bool = True,
     ) -> None:
         super().__init__()
-        self._splitter = DatetimeIndexSplitter(schedule, before, after=after, n_splits=n_splits, flex=flex)
+        self._splitter = DatetimeIndexSplitter(
+            schedule,
+            before=before,
+            after=after,
+            step=step,
+            n_splits=n_splits,
+            flex=flex,
+        )
         self.log_progress = log_progress
         self.verify_xy = verify_xy
 

--- a/src/rics/ml/time_split/types.py
+++ b/src/rics/ml/time_split/types.py
@@ -18,24 +18,7 @@ Schedule = _t.Union[_pd.DatetimeIndex, DatetimeIterable, TimedeltaTypes]
 Span = _t.Union[int, _t.Literal["all"], TimedeltaTypes]
 """User span type. Used to determine limits from the timestamps given by a :attr:`Schedule`."""
 Flex = _t.Union[bool, _t.Literal["auto"], str]
-"""Flexibility frequency string for ``floor/ceil``. Pass ``False`` to disable.
-
-Options `'auto'` (**default**) and ``True`` are equivalent. Available data limits ``(start, end)`` are rounded using
-:meth:`Timestamp.floor <pandas.Timestamp.floor>` and :meth:`Timestamp.ceil <pandas.Timestamp.ceil>`, respectively. In
-other words, the start of the range is always rounded down while the end is rounded up.
-
-Auto flex:
-    When using ``flex='auto'`` (**default**), if and how bounds are expanded is determined by the size of the range and
-    by distance between the actual and desired limits.
-
-    Use :attr:`settings.auto_flex <rics.ml.time_split.settings.auto_flex>` to modify auto-flex behaviour.
-
-Manual flex:
-    Pass an :ref:`offset alias <pandas:timeseries.offset_aliases>` specify how limits should be rounded. To specify by
-    `how much` limits may be rounded, pass ``'<'`` follow by a valid :class:`pandas.Timedelta`-string.
-
-    See :func:`~rics.ml.time_split.support.expand_limits` for usage examples.
-"""
+"""Flexibility frequency string for ``floor/ceil``. Pass ``False`` to disable."""
 
 
 class DatetimeSplitBounds(_t.NamedTuple):

--- a/tests/ml/time_split/test_plot.py
+++ b/tests/ml/time_split/test_plot.py
@@ -51,7 +51,7 @@ def test_show_removed(n_splits):
 
     ax = plot("3d", available=("2022", "2022-2"), n_splits=n_splits, bar_labels=False, show_removed=True)
     xtick_labels = [t.get_text() for t in ax.get_yticklabels()]
-    assert [str(n) for n in range(1, n_splits + 1)] == xtick_labels
+    assert xtick_labels == ["" for _ in range(7 - n_splits)] + [str(n) for n in range(1, n_splits + 1)]
 
 
 @pytest.mark.parametrize("factory", [pd.Series, pd.Index, list])
@@ -87,3 +87,18 @@ def random_density_timestamps() -> Tuple[pd.Timestamp, ...]:
         start = start + pd.Timedelta(hours=1)
         prev_size = size
     return tuple(parts)
+
+
+@pytest.mark.parametrize(
+    "step, n_splits, expected",
+    [
+        (2, None, "1,,2,,3,,4"),
+        (-2, None, "1,,2,,3,,4"),
+        (2, 3, ",,1,,2,,3"),
+    ],
+)
+def test_step(step, n_splits, expected):
+    data = pd.date_range("2022-01", "2022-03")
+    ax = plot("0 0 * * THU", after="5d", step=step, n_splits=n_splits, available=data, show_removed=True)
+    xtick_labels = [t.get_text() for t in ax.get_yticklabels()]
+    assert xtick_labels == expected.split(",")

--- a/tests/ml/time_split/test_split.py
+++ b/tests/ml/time_split/test_split.py
@@ -37,3 +37,36 @@ def test_no_data(after, expected):
         right = st.DatetimeSplitBounds(*map(pd.Timestamp, right))
         assert left == right, i
     assert len(expected) == len(actual)
+
+
+@pytest.mark.parametrize(
+    "step, expected",
+    [
+        (1, ["2022-01-13", "2022-01-20", "2022-01-27", "2022-02-03", "2022-02-10", "2022-02-17", "2022-02-24"]),
+        (2, ["2022-01-13", "2022-01-27", "2022-02-10", "2022-02-24"]),
+        (3, ["2022-01-13", "2022-02-03", "2022-02-24"]),
+        (4, ["2022-01-27", "2022-02-24"]),
+        (7, ["2022-02-24"]),
+        (8, ["2022-02-24"]),
+    ],
+)
+class TestStep:
+    @staticmethod
+    def split(step, n_splits):
+        return split(
+            "0 0 * * THU",
+            after="5d",
+            available=pd.date_range("2022-01", "2022-03"),
+            step=step,
+            n_splits=n_splits,
+        )
+
+    def test_positive_and_negative(self, step, expected):
+        assert [f.mid for f in self.split(step, n_splits=None)] == [pd.Timestamp(e) for e in expected]
+        assert [f.mid for f in self.split(-step, n_splits=None)] == [pd.Timestamp(e) for e in reversed(expected)]
+
+    @pytest.mark.parametrize("n_splits", [2, 3])
+    def test_n_split(self, n_splits, step, expected):
+        expected = expected[-n_splits:]
+        assert [f.mid for f in self.split(step, n_splits=n_splits)] == [pd.Timestamp(e) for e in expected]
+        assert [f.mid for f in self.split(-step, n_splits=n_splits)] == [pd.Timestamp(e) for e in reversed(expected)]


### PR DESCRIPTION
* Add a `step` argument for selecting subsets of folds)
  * Prefer later folds (like `n_splits`).
  * Add example
  * Add tests
* Fixup some docs.

![Plot with step=2 and n_splits=3](https://github.com/rsundqvist/rics/assets/7727900/4244c36e-1d6d-418c-bf5d-41d8baf23fed)
