### PR TITLE
misc.tname: add attrs argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New `step` argument to `rics.ml.time_split` splitting functions.
+- New argument `attrs` to the `misc.name()`-function. Default is `'func'` (name used by `functools.partial`).
 
 ## [3.1.0] - 2023-10-13
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -73,6 +73,16 @@ class Test_tname:
     def test_with_class(self, obj, expected):
         assert misc.tname(obj, prefix_classname=True) == expected
 
+    @pytest.mark.parametrize("n_wraps", [1, 2, 4])
+    def test_wrapped(self, obj, expected, n_wraps):
+        class Wrapper:
+            def __init__(self, func):
+                self.func = func
+
+        for _ in range(n_wraps):
+            obj = Wrapper(obj)
+        assert misc.tname(obj, prefix_classname=True) == expected
+
 
 def test_get_local_or_remote(tmp_path):
     def my_postprocessor(p):


### PR DESCRIPTION
Default `attrs='func'` is used by functools.partial().

```python
from functools import partial
from sklearn.metrics import roc_auc_score
from rics.misc import tname

wrapped = partial(roc_auc_score, average="weighted")

tname(wrapped)
'roc_auc_score'

tname(wrapped, attrs=None)
'partial'
```