### PR TITLE
Add `rics.strings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * New module `rics.paths`; `paths.parse_any_path()`, derived functions `any_path_to_str()` and `any_path_to_path()`.
+* New module `rics.strings`. Moved `format_perf_counter()` and `format_seconds()`.
 
 ### Deprecated
-* Module `rics.ml.time_split` use `time-split` [![PyPI - Version](https://img.shields.io/pypi/v/time-split.svg)](https://pypi.python.org/pypi/time-split) package instead
+* Module `rics.ml.time_split` use `time-split` [![PyPI - Version](https://img.shields.io/pypi/v/time-split.svg)](https://pypi.python.org/pypi/time-split) package instead.
+* Functions `rics.performance.format_perf_counter()` and `format_seconds()`. Use `rics.strings`-functions instead.
 
 ## [4.0.1] - 2024-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * New module `rics.paths`; `paths.parse_any_path()`, derived functions `any_path_to_str()` and `any_path_to_path()`.
 * New module `rics.strings`. Moved `format_perf_counter()` and `format_seconds()`.
+* New function `strings.format_bytes()`.
 
 ### Deprecated
 * Module `rics.ml.time_split` use `time-split` [![PyPI - Version](https://img.shields.io/pypi/v/time-split.svg)](https://pypi.python.org/pypi/time-split) package instead.

--- a/src/rics/performance/_format_perf_counter.py
+++ b/src/rics/performance/_format_perf_counter.py
@@ -1,81 +1,23 @@
-from time import perf_counter
-
-FORMAT_AS_MINUTE_LIMIT = 60.0
-FORMAT_SECOND_SINGLE_DECIMAL = 1.0
-FORMAT_SECOND_DOUBLE_DECIMAL = 0.5
+from rics import strings
 
 
 def format_perf_counter(start: float, end: float | None = None) -> str:
-    """Format performance counter output.
-
-    This function formats performance counter output based on the time elapsed. For ``t < 120 sec``, accuracy is
-    increased whereas for durations above one minute a more user-friendly formatting is used.
-
-    Args:
-        start: Start time.
-        end: End time. Set to now if not given.
-
-    Returns:
-        A formatted performance counter time.
-
-    Examples:
-        >>> format_perf_counter(0, 309613.49)
-        '3d 14h 0m 13s'
-        >>> format_perf_counter(0, 0.154)
-        '154ms'
-        >>> format_perf_counter(0, 31.39)
-        '31.4s'
-
-    See Also:
-        :py:func:`time.perf_counter`
-
-    """
-    t = (end or perf_counter()) - start
-    return format_seconds(t)
+    """Deprecated alias of :func:`rics.strings.format_perf_counter`."""
+    _warn("format_perf_counter")
+    return strings.format_perf_counter(start, end=end)
 
 
-def format_seconds(t: float, *, allow_negative: bool = False) -> str:  # noqa: PLR0911
-    """Format performance counter output.
+def format_seconds(t: float, *, allow_negative: bool = False) -> str:
+    """Deprecated alias of :func:`rics.strings.format_seconds`."""
+    _warn("format_seconds")
+    return strings.format_seconds(t, allow_negative=allow_negative)
 
-    This function formats performance counter output based on the time elapsed. For ``t < 120 sec``, accuracy is
-    increased whereas for durations above one minute a more user-friendly formatting is used.
 
-    Args:
-        t: Time in seconds.
-        allow_negative: If ``True``, format negative `t` with a leading minus sign.
+def _warn(name: str) -> None:
+    import warnings
 
-    Returns:
-        A formatted performance counter time.
-
-    Raises:
-        ValueError: If ``t < 0`` and ``allow_negative=False`` (the default).
-
-    """
-    if t < 0:
-        if not allow_negative:
-            allow_negative = True
-            raise ValueError(f"Refuse to format {t=} < 0; to allow, set {allow_negative=}")
-        return f"-{format_seconds(abs(t))}"
-
-    if t > FORMAT_AS_MINUTE_LIMIT:
-        days, seconds = divmod(round(t), 86400)
-        hours, seconds = divmod(seconds, 3600)
-        minutes, seconds = divmod(seconds, 60)
-
-        parts = (days, hours, minutes, seconds)
-        nonzero = tuple(p > 0 for p in parts)
-        start, stop = nonzero.index(True), len(nonzero) - nonzero[::-1].index(True)
-        return " ".join(f"{parts[i]}{'dhms'[i]}" for i in range(start, stop))
-
-    if t >= FORMAT_SECOND_SINGLE_DECIMAL:
-        return f"{t:.1f}s"
-    if t > FORMAT_SECOND_DOUBLE_DECIMAL:
-        return f"{t:.2f}s"
-    if t > 10**-3:
-        return f"{t * 10 ** 3:.0f}ms"
-    if t > 10**-6:  # 1 μs
-        return f"{t * 10 ** 6:.0f}μs"
-    if t > 10**-9:
-        return f"{t * 10 ** 9:.0f}ns"
-
-    return f"{t:.3g}s"
+    msg = (
+        f"Function `rics.performance.{name}()` is deprecated."
+        f"\nUse `rics.strings.{name}()` instead, or pin `rics==4.0.1` to hide this warning."
+    )
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=3)

--- a/src/rics/performance/_multi_case_timer.py
+++ b/src/rics/performance/_multi_case_timer.py
@@ -4,8 +4,9 @@ from collections.abc import Collection, Hashable, Mapping
 from timeit import Timer
 from typing import Any, Generic, TypeAlias
 
+from rics.strings import format_seconds as fmt_time
+
 from ..misc import tname
-from ._format_perf_counter import format_seconds as fmt_time
 from .types import CandFunc, DataType, ResultsDict
 
 CandidateMethodArg: TypeAlias = dict[str, CandFunc[DataType]] | Collection[CandFunc[DataType]] | CandFunc[DataType]

--- a/src/rics/strings.py
+++ b/src/rics/strings.py
@@ -1,0 +1,105 @@
+"""Utility functions that act on or produce strings."""
+
+
+def format_perf_counter(start: float, *, end: float | None = None) -> str:
+    """Format performance counter output.
+
+    This function formats performance counter output based on the time elapsed. This is a thin wrapper around the
+    :func:`~rics.strings.format_seconds` function.
+
+    Args:
+        start: Start time.
+        end: End time. Retrieved using :py:func:`time.perf_counter` if ``None``.
+
+    Returns:
+        A formatted performance counter time.
+
+    Examples:
+        Basic usage.
+
+        >>> import time
+        >>> start = time.perf_counter()
+        >>> time.sleep(1219.0)  # doctest: +SKIP
+        >>> format_perf_counter(start)  # doctest: +SKIP
+        '20m 19s'
+
+        With no `end` argument given, the current time is retrieved using :py:func:`time.perf_counter`.
+    """
+    from time import perf_counter
+
+    end = perf_counter() if end is None else end
+    return format_seconds(end - start)
+
+
+def format_seconds(t: float, *, allow_negative: bool = False) -> str:
+    """Format performance counter output.
+
+    Args:
+        t: Time in seconds.
+        allow_negative: If ``True``, format negative `t` with a leading minus sign.
+
+    Returns:
+        A formatted performance counter time.
+
+    Examples:
+        Basic usage.
+
+        >>> format_seconds(0.0000154)
+        '15μs'
+        >>> format_seconds(0.154)
+        '154ms'
+        >>> format_seconds(31.39)
+        '31.4s'
+
+        Clock units are used for `t > 60` seconds.
+
+        >>> format_seconds(59.99)
+        '60.0s'
+        >>> format_seconds(60.00)
+        '60.0s'
+        >>> format_seconds(60.01)
+        '1m'
+        >>> format_seconds(309613.49)
+        '3d 14h 0m 13s'
+
+    Raises:
+        ValueError: If ``t < 0`` and ``allow_negative=False`` (the default).
+
+    """
+    if t < 0:
+        if not allow_negative:
+            allow_negative = True
+            raise ValueError(f"Refuse to format {t=} < 0; to allow, set {allow_negative=}")
+        return f"-{format_seconds(abs(t))}"
+
+    long_limit: float = 60.0
+    return _format_seconds(t) if t <= long_limit else _format_minutes(t)
+
+
+def _format_minutes(t: float) -> str:
+    days, seconds = divmod(round(t), 86400)
+    hours, seconds = divmod(seconds, 3600)
+    minutes, seconds = divmod(seconds, 60)
+    parts = (days, hours, minutes, seconds)
+    nonzero = tuple(p > 0 for p in parts)
+    start, stop = nonzero.index(True), len(nonzero) - nonzero[::-1].index(True)
+    return " ".join(f"{parts[i]}{'dhms'[i]}" for i in range(start, stop))
+
+
+def _format_seconds(t: float) -> str:
+    single_decimal_limit: float = 1.0
+    if t >= single_decimal_limit:
+        return f"{t:.1f}s"
+
+    double_decimal_limit: float = 0.5
+    if t > double_decimal_limit:
+        return f"{t:.2f}s"
+
+    if t > 10**-3:
+        return f"{t * 10 ** 3:.0f}ms"
+    if t > 10**-6:  # 1 μs
+        return f"{t * 10 ** 6:.0f}μs"
+    if t > 10**-9:
+        return f"{t * 10 ** 9:.0f}ns"
+
+    return f"{t:.3g}s"

--- a/tests/performance/test_util.py
+++ b/tests/performance/test_util.py
@@ -1,0 +1,14 @@
+import pytest
+from rics.performance import format_perf_counter, format_seconds
+
+
+class TestDeprecated:
+    def format_perf_counter(self):
+        with pytest.warns(DeprecationWarning, match="format_perf_counter"):
+            actual = format_perf_counter(0, 7794363.9)
+        assert actual == "90d 5h 6m 4s"
+
+    def test_seconds(self):
+        with pytest.warns(DeprecationWarning, match="format_seconds"):
+            actual = format_seconds(7794363.9)
+        assert actual == "90d 5h 6m 4s"

--- a/tests/test_strings/test_format_time.py
+++ b/tests/test_strings/test_format_time.py
@@ -1,12 +1,12 @@
 import pytest
-from rics.performance import format_perf_counter, format_seconds
+from rics.strings import format_perf_counter, format_seconds
 
 
 class Base:
     @staticmethod
     def test_positive(t, expected):
         assert format_seconds(t) == expected
-        assert format_perf_counter(0, t) == expected
+        assert format_perf_counter(0, end=t) == expected
 
     @staticmethod
     def test_negative(t, expected):
@@ -69,11 +69,25 @@ class TestClock(Base):
 @pytest.mark.parametrize(
     "t, expected",
     [
-        (119.5, "2m"),
+        (59.99, "60.0s"),
+        (60.00, "60.0s"),
+        (60.01, "1m"),
+        (61.0, "1m 1s"),
+    ],
+)
+class TestClockTransition(Base):
+    pass
+
+
+@pytest.mark.parametrize(
+    "t, expected",
+    [
         (119.49, "1m 59s"),
-        (3599.5, "1h"),
+        (119.50, "2m"),
+        (119.51, "2m"),
+        (3599.50, "1h"),
         (3599.49, "59m 59s"),
-        (3659.5, "1h 1m"),
+        (3659.50, "1h 1m"),
         (3659.49, "1h 0m 59s"),
     ],
 )


### PR DESCRIPTION
* Moved implementations of `rics.performance.format_perf_counter()` and `format_seconds()` to new module `rics.strings`. Old functions still exist but delegate to new function after emitting a `DeprecationWarning`.
* Added function `rics.strings.format_bytes()`.
