### PR TITLE
feat(performance): ergonomics improvements (setup/warmup, relative_to, tidy, plot hue, progress fallback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `performance.MultiCaseTimer.run()` now accepts `setup` (a ``(data) -> data`` callable run unmeasured before each
   timed repetition, mirroring `timeit`) and `warmup` (untimed calls before timing). Resolves #398.
+- `performance.relative_to()`: compare candidates against a baseline candidate (per-pair speedup table + geometric mean).
 
 ## [6.1.4] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `performance.MultiCaseTimer.run()` now accepts `setup` (a ``(data) -> data`` callable run unmeasured before each
   timed repetition, mirroring `timeit`) and `warmup` (untimed calls before timing). Resolves #398.
 - `performance.relative_to()`: compare candidates against a baseline candidate (per-pair speedup table + geometric mean).
+- `performance.to_dataframe(tidy=True)`: return a minimal analysis frame (`candidate`/`data`/`*names`/`run`/`seconds`)
+  without presentation columns.
 
 ## [6.1.4] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `performance.to_dataframe(tidy=True)`: return a minimal analysis frame (`candidate`/`data`/`*names`/`run`/`seconds`)
   without presentation columns.
 - `performance.plot_run(relative_to=<baseline>)`: plot per-candidate speedup against a baseline (dimensionless y-axis
-  with a reference line at `1.0`) instead of absolute timings.
+  with a reference line at `1.0`) instead of absolute timings. The baseline is shown as the reference line and omitted
+  from the bars.
 
 ### Changed
 - `performance.plot_run()` now accepts an explicit `hue` argument, and both `x` and `hue` may reference a test-data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   col='source')`.
 - `performance.MultiCaseTimer.run(progress=True)` falls back to periodic `logging` when output is not a TTY (instead of
   `tqdm` carriage-return spam), making `tqdm` optional in non-interactive runs.
+- Clarified the `run()` time-budget docstring: total runtime is ``repeat * time_per_candidate * n_candidates`` and is
+  independent of the number of test-data variants.
 
 ## [6.1.4] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `performance.MultiCaseTimer.run()` now accepts `setup` (a ``(data) -> data`` callable run unmeasured before each
+  timed repetition, mirroring `timeit`) and `warmup` (untimed calls before timing). Resolves #398.
+
 ## [6.1.4] - 2026-06-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `performance.plot_run()` now accepts an explicit `hue` argument, and both `x` and `hue` may reference a test-data
   dimension `name` (not just `'candidate'`/`'data'`). Enables e.g. `plot_run(..., x='rows', hue='candidate',
   col='source')`.
+- `performance.MultiCaseTimer.run(progress=True)` falls back to periodic `logging` when output is not a TTY (instead of
+  `tqdm` carriage-return spam), making `tqdm` optional in non-interactive runs.
 
 ## [6.1.4] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `performance.to_dataframe(tidy=True)`: return a minimal analysis frame (`candidate`/`data`/`*names`/`run`/`seconds`)
   without presentation columns.
 
+### Changed
+- `performance.plot_run()` now accepts an explicit `hue` argument, and both `x` and `hue` may reference a test-data
+  dimension `name` (not just `'candidate'`/`'data'`). Enables e.g. `plot_run(..., x='rows', hue='candidate',
+  col='source')`.
+
 ## [6.1.4] - 2026-06-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `performance.relative_to()`: compare candidates against a baseline candidate (per-pair speedup table + geometric mean).
 - `performance.to_dataframe(tidy=True)`: return a minimal analysis frame (`candidate`/`data`/`*names`/`run`/`seconds`)
   without presentation columns.
+- `performance.plot_run(relative_to=<baseline>)`: plot per-candidate speedup against a baseline (dimensionless y-axis
+  with a reference line at `1.0`) instead of absolute timings.
 
 ### Changed
 - `performance.plot_run()` now accepts an explicit `hue` argument, and both `x` and `hue` may reference a test-data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix multiple issues in the `Variable.parse_string()` method.
 - Fix `VenvHelper` breakout issues for; would sync the wrong `uv` environment.
+- The `MultiCaseTimer.run()` method now calls `skip_if` during the autonumber phase.
 
 ## [6.1.3] - 2026-03-07
 

--- a/src/rics/performance/__init__.py
+++ b/src/rics/performance/__init__.py
@@ -3,7 +3,7 @@
 from ._format_perf_counter import format_perf_counter, format_seconds
 from ._multi_case_timer import MultiCaseTimer, SkipIfParams
 from ._plot import plot_run
-from ._util import get_best, legacy_plot_run, to_dataframe
+from ._util import get_best, legacy_plot_run, relative_to, to_dataframe
 from ._wrapper import run_multivariate_test
 
 __all__ = [
@@ -14,6 +14,7 @@ __all__ = [
     "get_best",
     "legacy_plot_run",
     "plot_run",
+    "relative_to",
     "run_multivariate_test",
     "to_dataframe",
 ]

--- a/src/rics/performance/_multi_case_timer.py
+++ b/src/rics/performance/_multi_case_timer.py
@@ -159,7 +159,7 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
 
         logger.debug("Begin evaluating %i combinations: %i candidates and %i test cases.", total, n_cand, n_data)
 
-        per_candidate_number = self._compute_number_of_iterations(number, repeat, time_per_candidate, progress)
+        per_candidate_number = self._compute_number_of_iterations(number, repeat, time_per_candidate, progress, skip_if)
 
         if progress:
             from tqdm.auto import tqdm
@@ -171,7 +171,11 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
         i = 0
         run_results: ResultsDict = {}
         for candidate_label, func in self._candidates.items():
-            candidate_number, candidate_est_time = per_candidate_number[candidate_label]
+            params = per_candidate_number[candidate_label]
+            if params is None:
+                continue
+
+            candidate_number, candidate_est_time = params
             run_results[candidate_label] = candidate_results = {}
 
             logger.info(f"Evaluate candidate {candidate_label!r} {repeat}x{candidate_number} times per datum..")
@@ -232,7 +236,8 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
         repeat: int,
         time_allocation: float,
         progress: bool,
-    ) -> dict[str, tuple[int, float]] | dict[str, tuple[int, None]]:
+        skip_if: "Callable[[SkipIfParams[DataType, *Ts]], bool] | None" = None,
+    ) -> dict[str, tuple[int, float | None] | None]:
         logger = self.LOGGER
 
         if isinstance(number, int):
@@ -248,14 +253,21 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
         else:
             pbar = None
 
-        candidate_numbers = {}
+        # {candidate: (number, est_time | None) | None}, where None values are skip_if-filtered candidates.
+        numbers: dict[str, tuple[int, float | None] | None] = {}
         for label in self._candidates:
             if pbar:
                 pbar.desc = f"autorange('{label}')"
                 pbar.refresh()
 
-            number, time = self._autonumber(time_allocation, label)
-            candidate_numbers[label] = number, time
+            autonumber = self._autonumber(time_allocation, label, skip_if)
+            if autonumber is None:
+                logger.warning(f"Discarding candidate={label!r}; skipped by {tname(skip_if)} at {time_allocation=}.")
+                numbers[label] = None
+                continue
+
+            number, time = autonumber
+            numbers[label] = number, time
             logger.debug("Candidate number for candidate=%r: %i (time=%f).", label, number, time)
             if pbar:
                 pbar.update()
@@ -263,25 +275,54 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
         if pbar:
             pbar.clear()
 
-        logger.info(
-            f"Computed shared number for {len(candidate_numbers)} candidates in {format_perf_counter(start)}: "
-            f"{candidate_numbers}."
-        )
+        kept = {k: v for k, v in numbers.items() if v is not None}
+        if kept:
+            logger.info(f"Computed shared number for {len(kept)} candidates in {format_perf_counter(start)}: {kept}.")
+        else:
+            logger.warning(f"All candidates {len(numbers)} discarded by {tname(skip_if)} at {time_allocation=}.")
 
-        return candidate_numbers
+        return numbers
 
-    def _autonumber(self, time_allocation: float, candidate_label: str) -> tuple[int, float]:
+    def _autonumber(
+        self,
+        time_allocation: float,
+        candidate_label: str,
+        skip_if: "Callable[[SkipIfParams[DataType, *Ts]], bool] | None",
+    ) -> tuple[int, float] | None:
         """Based on Timer.autorange()."""
+        func = self._candidates[candidate_label]
+
+        def should_skip(data_label: Hashable, data: DataType) -> bool:
+            if skip_if is None:
+                return False
+
+            params: SkipIfParams[DataType, *Ts] = SkipIfParams(
+                candidate=func,
+                candidate_label=candidate_label,
+                data=data,
+                data_label=data_label,
+                est_time=None,
+                results_so_far={},
+            )
+
+            return skip_if(params)
+
         i = 1
         while True:
             for j in 1, 2, 3, 5:
                 number = i * j
 
                 total_time_taken = 0.0
-                for data in self._data.values():
-                    func = self._candidates[candidate_label]
+                all_skipped = True
+                for data_label, data in self._data.items():
+                    if should_skip(data_label, data):
+                        continue
+                    all_skipped = False
                     partial = functools.partial(func, data)
                     total_time_taken += Timer(partial).timeit(number)
+
+                if all_skipped:
+                    return None
 
                 if total_time_taken >= time_allocation:
                     if total_time_taken > 1:

--- a/src/rics/performance/_multi_case_timer.py
+++ b/src/rics/performance/_multi_case_timer.py
@@ -14,6 +14,9 @@ from rics.strings import format_seconds as fmt_time
 
 from .types import CandFunc, DataFunc, DataType, ResultsDict, Ts
 
+SetupFunc: TypeAlias = Callable[[DataType], DataType]
+"""A callable ``(data) -> data`` run -- unmeasured -- before each timed repetition to produce a fresh input."""
+
 UNRELIABLE_RESULTS_LIMIT = 1e-6  # Prevent spurious "4x" warnings.
 
 CandidateMethodArg: TypeAlias = Mapping[str, CandFunc[DataType]] | Collection[CandFunc[DataType]] | CandFunc[DataType]
@@ -121,6 +124,8 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
         repeat: int = 5,
         number: int | None = None,
         skip_if: Callable[["SkipIfParams[DataType, *Ts]"], bool] | None = None,
+        setup: SetupFunc[DataType] | None = None,
+        warmup: int = 0,
         progress: bool = False,
     ) -> ResultsDict:
         """Run for all cases.
@@ -133,6 +138,10 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
             repeat: Number of times to repeat for all candidates per data label.
             number: Number of times to execute each candidate, per repetition.
             skip_if: A callable ``(skip_if) -> bool``; see the :class:`params <SkipIfParams>` type.
+            setup: A callable ``(data) -> data`` invoked -- **not** measured -- before each timed repetition to produce a
+                fresh input (mirrors :py:class:`timeit.Timer`'s ``setup``). Use for candidates that mutate their input,
+                or to reset shared state (e.g. caches) between repetitions.
+            warmup: Number of untimed calls per candidate/data pair before timing begins (warms caches/JIT/imports).
             progress: If ``True``, display a progress bar. Requires ``tqdm``.
 
         Examples:
@@ -159,7 +168,9 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
 
         logger.debug("Begin evaluating %i combinations: %i candidates and %i test cases.", total, n_cand, n_data)
 
-        per_candidate_number = self._compute_number_of_iterations(number, repeat, time_per_candidate, progress, skip_if)
+        per_candidate_number = self._compute_number_of_iterations(
+            number, repeat, time_per_candidate, progress, skip_if=skip_if, setup=setup
+        )
 
         if progress:
             from tqdm.auto import tqdm
@@ -203,7 +214,9 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
 
                 logger.debug(f"Start evaluating combination {i}/{total}: {candidate_label!r} @ {data_label!r}.")
 
-                raw_timings = self._get_raw_timings(func, test_data, repeat, candidate_number)
+                raw_timings = self._get_raw_timings(
+                    func, test_data, repeat, candidate_number, setup=setup, warmup=warmup
+                )
 
                 timings = [dt / candidate_number for dt in raw_timings]
 
@@ -225,10 +238,38 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
 
         return run_results
 
-    @staticmethod
-    def _get_raw_timings(func: CandFunc[DataType], test_data: DataType, repeat: int, number: int) -> list[float]:
+    @classmethod
+    def _get_raw_timings(
+        cls,
+        func: CandFunc[DataType],
+        test_data: DataType,
+        repeat: int,
+        number: int,
+        *,
+        setup: SetupFunc[DataType] | None = None,
+        warmup: int = 0,
+    ) -> list[float]:
         """Exists so that it can be overridden for testing."""
-        return Timer(lambda: func(test_data)).repeat(repeat, number)
+        timer = cls._make_timer(func, test_data, setup)
+        for _ in range(warmup):
+            timer.timeit(1)
+        return timer.repeat(repeat, number)
+
+    @staticmethod
+    def _make_timer(func: CandFunc[DataType], test_data: DataType, setup: SetupFunc[DataType] | None) -> Timer:
+        """Build a :class:`timeit.Timer`. With `setup`, fresh input is produced (unmeasured) before each repetition."""
+        if setup is None:
+            return Timer(functools.partial(func, test_data))
+
+        holder: dict[str, DataType] = {}
+
+        def _setup() -> None:
+            holder["data"] = setup(test_data)
+
+        def _stmt() -> None:
+            func(holder["data"])
+
+        return Timer(_stmt, _setup)
 
     def _compute_number_of_iterations(
         self,
@@ -237,6 +278,7 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
         time_allocation: float,
         progress: bool,
         skip_if: "Callable[[SkipIfParams[DataType, *Ts]], bool] | None" = None,
+        setup: SetupFunc[DataType] | None = None,
     ) -> dict[str, tuple[int, float | None] | None]:
         logger = self.LOGGER
 
@@ -260,7 +302,7 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
                 pbar.desc = f"autorange('{label}')"
                 pbar.refresh()
 
-            autonumber = self._autonumber(time_allocation, label, skip_if)
+            autonumber = self._autonumber(time_allocation, label, skip_if, setup)
             if autonumber is None:
                 logger.warning(f"Discarding candidate={label!r}; skipped by {tname(skip_if)} at {time_allocation=}.")
                 numbers[label] = None
@@ -288,6 +330,7 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
         time_allocation: float,
         candidate_label: str,
         skip_if: "Callable[[SkipIfParams[DataType, *Ts]], bool] | None",
+        setup: SetupFunc[DataType] | None = None,
     ) -> tuple[int, float] | None:
         """Based on Timer.autorange()."""
         func = self._candidates[candidate_label]
@@ -318,8 +361,7 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
                     if should_skip(data_label, data):
                         continue
                     all_skipped = False
-                    partial = functools.partial(func, data)
-                    total_time_taken += Timer(partial).timeit(number)
+                    total_time_taken += self._make_timer(func, data, setup).timeit(number)
 
                 if all_skipped:
                     return None

--- a/src/rics/performance/_multi_case_timer.py
+++ b/src/rics/performance/_multi_case_timer.py
@@ -131,8 +131,11 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
     ) -> ResultsDict:
         """Run for all cases.
 
-        Note that the test case variant data isn't included in the expected runtime computation, so increasing the
-        amount of test data variants (at initialization) will reduce the amount of times each candidate is evaluated.
+        Time budget:
+            The total runtime is approximately ``repeat * time_per_candidate * n_candidates`` -- a single ``number`` is
+            derived **per candidate** (shared across all test-data variants, so candidates stay comparable). Adding more
+            test-data variants therefore does *not* increase the total time; it divides the per-candidate budget across
+            the variants. Pass `number` explicitly to bypass this calibration.
 
         Args:
             time_per_candidate: Minimum runtime per repetition and candidate label. Ignored if `number` is set.
@@ -147,8 +150,8 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
                 otherwise (so ``tqdm`` is optional).
 
         Examples:
-            If `repeat=5` and `time_per_candidate=3` for an instance with and 2 candidates, the total
-            runtime will be approximately ``5 * 3 * 2 = 30`` seconds.
+            If `repeat=5` and `time_per_candidate=3` for an instance with 2 candidates, the total runtime will be
+            approximately ``5 * 3 * 2 = 30`` seconds -- regardless of how many test-data variants are used.
 
         Returns:
             A dict `run_results` on the form ``{candidate_label: {data_label: [runtime, ...]}}``.

--- a/src/rics/performance/_multi_case_timer.py
+++ b/src/rics/performance/_multi_case_timer.py
@@ -12,6 +12,7 @@ from rics.misc import format_kwargs, tname
 from rics.strings import format_perf_counter
 from rics.strings import format_seconds as fmt_time
 
+from ._progress import make_progress
 from .types import CandFunc, DataFunc, DataType, ResultsDict, Ts
 
 SetupFunc: TypeAlias = Callable[[DataType], DataType]
@@ -142,7 +143,8 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
                 fresh input (mirrors :py:class:`timeit.Timer`'s ``setup``). Use for candidates that mutate their input,
                 or to reset shared state (e.g. caches) between repetitions.
             warmup: Number of untimed calls per candidate/data pair before timing begins (warms caches/JIT/imports).
-            progress: If ``True``, display a progress bar. Requires ``tqdm``.
+            progress: If ``True``, display progress. Uses ``tqdm`` on a TTY and falls back to periodic logging
+                otherwise (so ``tqdm`` is optional).
 
         Examples:
             If `repeat=5` and `time_per_candidate=3` for an instance with and 2 candidates, the total
@@ -172,12 +174,7 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
             number, repeat, time_per_candidate, progress, skip_if=skip_if, setup=setup
         )
 
-        if progress:
-            from tqdm.auto import tqdm
-
-            pbar = tqdm(total=total)
-        else:
-            pbar = None
+        pbar = make_progress(total, enabled=progress, logger=logger)
 
         i = 0
         run_results: ResultsDict = {}
@@ -192,9 +189,7 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
             logger.info(f"Evaluate candidate {candidate_label!r} {repeat}x{candidate_number} times per datum..")
             for data_label, test_data in self._data.items():
                 i += 1
-                if pbar:
-                    pbar.desc = f"{candidate_label}({data_label})"
-                    pbar.refresh()
+                pbar.set_description(f"{candidate_label}({data_label})")
 
                 if skip_if:
                     skip_if_params: SkipIfParams[DataType, *Ts] = SkipIfParams(
@@ -207,8 +202,7 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
                     )
 
                     if skip_if(skip_if_params):
-                        if pbar:
-                            pbar.update()
+                        pbar.update()
                         logger.debug(f"Skip combination {i}/{total}: {candidate_label!r} @ {data_label!r}.")
                         continue
 
@@ -233,9 +227,9 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
                     )
 
                 candidate_results[data_label] = timings
-                if pbar:
-                    pbar.update()
+                pbar.update()
 
+        pbar.close()
         return run_results
 
     @classmethod
@@ -288,19 +282,12 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
         logger.debug("Computing number of iterations with repeat=%i and time_allocation=%f.", repeat, time_allocation)
         start = perf_counter()
 
-        if progress:
-            from tqdm.auto import tqdm
-
-            pbar = tqdm(total=len(self._candidates))
-        else:
-            pbar = None
+        pbar = make_progress(len(self._candidates), enabled=progress, logger=logger)
 
         # {candidate: (number, est_time | None) | None}, where None values are skip_if-filtered candidates.
         numbers: dict[str, tuple[int, float | None] | None] = {}
         for label in self._candidates:
-            if pbar:
-                pbar.desc = f"autorange('{label}')"
-                pbar.refresh()
+            pbar.set_description(f"autorange('{label}')")
 
             autonumber = self._autonumber(time_allocation, label, skip_if, setup)
             if autonumber is None:
@@ -311,11 +298,9 @@ class MultiCaseTimer(Generic[DataType, *Ts]):
             number, time = autonumber
             numbers[label] = number, time
             logger.debug("Candidate number for candidate=%r: %i (time=%f).", label, number, time)
-            if pbar:
-                pbar.update()
+            pbar.update()
 
-        if pbar:
-            pbar.clear()
+        pbar.close()
 
         kept = {k: v for k, v in numbers.items() if v is not None}
         if kept:

--- a/src/rics/performance/_plot/_params.py
+++ b/src/rics/performance/_plot/_params.py
@@ -1,26 +1,29 @@
 from collections.abc import Hashable, Iterable, Mapping
 from dataclasses import dataclass, field, fields
-from typing import Any, ClassVar, Literal, Self
+from typing import Any, ClassVar, Self
 
 import numpy as np
 import pandas as pd
 
 from rics.collections.dicts import compute_if_absent
-from rics.performance.plot_types import Candidate, FuncOrData, Kind, TestData, Unit
-from rics.types import LiteralHelper
+from rics.performance.plot_types import Candidate, Kind, TestData, Unit
 
 from ..types import ResultsDict
 
 FUNC: Candidate = "Candidate"
 DATA: TestData = "Test data"
 
+# Keyword aliases accepted for the `x`/`hue` arguments, in addition to test-data dimension names.
+_ALIASES: dict[str, str] = {"candidate": FUNC, "func": FUNC, "data": DATA, "test data": DATA, FUNC: FUNC, DATA: DATA}
+_COMPLEMENT: dict[str, str] = {FUNC: DATA, DATA: FUNC}
+
 
 @dataclass(frozen=True, kw_only=True)
 class CatplotParams:
     data: pd.DataFrame = field(repr=False)
-    x: FuncOrData
+    x: str
     y: str
-    hue: FuncOrData
+    hue: str
     kind: Kind
 
     horizontal: bool = field(metadata={"skip": True})
@@ -48,20 +51,22 @@ class CatplotParams:
                 error.add_note(f"HINT ({y=}): Use `horizontal=True` to plot timings on the X-axis.")
             if "hue" in keys:
                 hue = self.user_kwargs["hue"]
-                error.add_note(f"HINT ({hue=}): Use `x='data' | 'candidate'` to control X-axis and Hue variables.")
+                error.add_note(f"HINT ({hue=}): Use the `hue=` argument of `plot_run` instead.")
 
             raise error
 
-        helper = LiteralHelper[FuncOrData](FuncOrData)
-        helper.check(self.x, "x")
-        helper.check(self.hue, "hue")
+        for role, column in (("x", self.x), ("hue", self.hue)):
+            if column not in self.data.columns:
+                msg = f"Bad {role}={column!r}; not a column in the data ({list(self.data.columns)})."
+                raise ValueError(msg)
 
     @classmethod
     def make(
         cls,
         run_results: ResultsDict | pd.DataFrame,
         *,
-        x: Literal["candidate", "data"] | None = None,
+        x: str | None = None,
+        hue: str | None = None,
         horizontal: bool = False,
         unit: Unit | None = None,
         kind: Kind = "bar",
@@ -72,8 +77,7 @@ class CatplotParams:
         names = [*names]
         df = _make_df(run_results, names)
 
-        # MyPy thinks these are both string
-        x_col, hue_col = (DATA, FUNC) if _is_data_x(x, df=df) else (FUNC, DATA)
+        x_col, hue_col = _resolve_x_hue(x, hue, names=names, df=df)
 
         return cls(
             data=df,
@@ -156,11 +160,11 @@ class CatplotParams:
             g = (template.format(lv) for i, lv in enumerate(label) if (template := formatters.get(i)))
             return " | ".join(g)
 
-        order_key = "hue_order" if self.hue == DATA else "order"
-        if old_order := kwargs.get(order_key):
-            updates[order_key] = np.unique([format_label(label) for label in old_order]).tolist()
-
-        # assert sorted(self.data.columns.intersection(names)) == sorted(names)
+        # Only the axis that actually shows the composite DATA label needs its order reformatted; x/hue bound to a
+        # single named dimension (or the candidate) keep their raw order.
+        for axis, order_key in (("x", "order"), ("hue", "hue_order")):
+            if getattr(self, axis) == DATA and (old_order := kwargs.get(order_key)):
+                updates[order_key] = np.unique([format_label(label) for label in old_order]).tolist()
 
         data = kwargs["data"].copy()
         data[DATA] = data[DATA].map(format_label)
@@ -188,12 +192,44 @@ def _make_df(run_results: ResultsDict | pd.DataFrame, names: list[str]) -> pd.Da
     return df
 
 
-def _is_data_x(x_col: Literal["candidate", "data"] | None, *, df: pd.DataFrame) -> bool:
+def _resolve_x_hue(
+    x: str | None,
+    hue: str | None,
+    *,
+    names: list[str],
+    df: pd.DataFrame,
+) -> tuple[str, str]:
+    """Resolve `x` and `hue` to real column names.
+
+    Accepts the ``'candidate'``/``'data'`` aliases, a test-data dimension `name`, or a raw column. When omitted, `x`
+    defaults to the complement of `hue` (or the higher-cardinality of candidate/data), and `hue` to the complement of
+    `x` (falling back to the candidate column when `x` is a named dimension).
+    """
+
+    def resolve(value: str | None, role: str) -> str | None:
+        if value is None:
+            return None
+        column = _ALIASES.get(value.lower(), value)
+        if column not in df.columns and column not in names:
+            allowed = ["candidate", "data", *names]
+            msg = f"Bad {role}={value!r}; expected one of {allowed} or a data column."
+            raise ValueError(msg)
+        return column
+
+    x_col = resolve(x, "x")
+    hue_col = resolve(hue, "hue")
+
     if x_col is None:
-        n_data, n_func = df[[DATA, FUNC]].nunique()
-        return n_data > n_func  # type: ignore[no-any-return]
-    else:
-        return x_col.lower().startswith("d")
+        if hue_col in _COMPLEMENT:
+            x_col = _COMPLEMENT[hue_col]
+        else:
+            n_data, n_func = df[[DATA, FUNC]].nunique()
+            x_col = DATA if n_data > n_func else FUNC
+
+    if hue_col is None:
+        hue_col = _COMPLEMENT.get(x_col, FUNC)
+
+    return x_col, hue_col
 
 
 def _resolve_y(unit: Unit | None, *, df: pd.DataFrame) -> str:

--- a/src/rics/performance/_plot/_params.py
+++ b/src/rics/performance/_plot/_params.py
@@ -223,6 +223,8 @@ def _make_speedup_df(
     from rics.performance import relative_to
 
     summary = relative_to(run_results, baseline=baseline, names=names, agg=agg)
+    # The baseline is definitionally speedup==1.0; it's shown as the reference line, so drop its (flat) bars.
+    summary = summary[summary["candidate"] != baseline]
     df = summary.rename(columns={"candidate": FUNC, "data": DATA})
     df[[DATA, FUNC]] = df[[DATA, FUNC]].astype("category")
     return df

--- a/src/rics/performance/_plot/_params.py
+++ b/src/rics/performance/_plot/_params.py
@@ -1,6 +1,6 @@
 from collections.abc import Hashable, Iterable, Mapping
 from dataclasses import dataclass, field, fields
-from typing import Any, ClassVar, Self
+from typing import TYPE_CHECKING, Any, ClassVar, Self
 
 import numpy as np
 import pandas as pd
@@ -9,6 +9,9 @@ from rics.collections.dicts import compute_if_absent
 from rics.performance.plot_types import Candidate, Kind, TestData, Unit
 
 from ..types import ResultsDict
+
+if TYPE_CHECKING:
+    from ..plot_types import Aggregation
 
 FUNC: Candidate = "Candidate"
 DATA: TestData = "Test data"
@@ -29,6 +32,8 @@ class CatplotParams:
     horizontal: bool = field(metadata={"skip": True})
     names: list[str] = field(metadata={"skip": True})
     user_kwargs: Mapping[str, Any] = field(metadata={"skip": True})
+    reference: float | None = field(default=None, metadata={"skip": True})
+    """Reference value for the metric axis (e.g. ``1.0`` in speedup mode); draws a guide line. ``None`` disables."""
 
     DEFAULTS: ClassVar[dict[str, Any]] = {"errorbar": "sd", "estimator": "min", "aspect": 2}
     DEFAULTS_BY_KIND: ClassVar[dict[Kind, dict[str, Any]]] = {
@@ -71,22 +76,36 @@ class CatplotParams:
         unit: Unit | None = None,
         kind: Kind = "bar",
         names: Iterable[str] = (),
+        relative_to: str | None = None,
+        agg: "Aggregation" = "min",
         **kwargs: Any,
     ) -> Self:
         """Create instance from run results."""
         names = [*names]
-        df = _make_df(run_results, names)
+
+        if relative_to is None:
+            df = _make_df(run_results, names)
+            y = _resolve_y(unit, df=df)
+            reference = None
+        else:
+            if unit is not None:
+                msg = f"Cannot combine {unit=} with relative_to={relative_to!r}; speedup is dimensionless."
+                raise ValueError(msg)
+            df = _make_speedup_df(run_results, baseline=relative_to, names=names, agg=agg)
+            y = "speedup"
+            reference = 1.0
 
         x_col, hue_col = _resolve_x_hue(x, hue, names=names, df=df)
 
         return cls(
             data=df,
             x=x_col,
-            y=_resolve_y(unit, df=df),
+            y=y,
             horizontal=horizontal,
             hue=hue_col,
             kind=kind,
             names=names,
+            reference=reference,
             user_kwargs={**kwargs},
         )
 
@@ -137,6 +156,8 @@ class CatplotParams:
             case "hue_order":
                 return df[self.hue].unique().tolist()
             case "log_scale":
+                if self.reference is not None:
+                    return None  # Speedup is a linear ratio; the reference line marks the baseline.
                 column = next(filter(lambda c: c.startswith("Time ["), df.columns))
                 means = df.groupby([DATA, FUNC], observed=True)[column].mean()
                 return (False, True) if means.max() / means.min() > 20 else None  # noqa: PLR2004
@@ -189,6 +210,21 @@ def _make_df(run_results: ResultsDict | pd.DataFrame, names: list[str]) -> pd.Da
 
     as_category = [DATA, FUNC]
     df[as_category] = df[as_category].astype("category")
+    return df
+
+
+def _make_speedup_df(
+    run_results: ResultsDict | pd.DataFrame,
+    *,
+    baseline: str,
+    names: list[str],
+    agg: "Aggregation",
+) -> pd.DataFrame:
+    from rics.performance import relative_to
+
+    summary = relative_to(run_results, baseline=baseline, names=names, agg=agg)
+    df = summary.rename(columns={"candidate": FUNC, "data": DATA})
+    df[[DATA, FUNC]] = df[[DATA, FUNC]].astype("category")
     return df
 
 

--- a/src/rics/performance/_plot/_plot.py
+++ b/src/rics/performance/_plot/_plot.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
@@ -17,7 +17,8 @@ if TYPE_CHECKING:
 def plot_run(
     run_results: ResultsDict | pd.DataFrame,
     *,
-    x: Literal["candidate", "data"] | None = None,
+    x: str | None = None,
+    hue: str | None = None,
     horizontal: bool = False,
     unit: Unit | None = None,
     kind: Kind = "bar",
@@ -62,12 +63,15 @@ def plot_run(
 
     Args:
         run_results: Output of :meth:`.MultiCaseTimer.run`.
-        x: X-axis quantity; ``candidate'`` or ``'data'``. The other will be used as the hue.
+        x: X-axis quantity: ``'candidate'``, ``'data'``, or one of `names` (a test-data dimension). If omitted, defaults
+            to the complement of `hue` (or the higher-cardinality of candidate/data).
+        hue: Hue quantity: ``'candidate'``, ``'data'``, or one of `names`. If omitted, defaults to the complement of `x`
+            (or the candidate when `x` is a named dimension).
         horizontal: If ``True``, plot timings on the X-axis instead. The `x` becomes the new Y-axis quantity.
         unit: Y-axis time :attr:`~rics.performance.plot_types.Unit`.
         kind: The :attr:`~rics.performance.plot_types.Kind` of plot to draw.
         names: Test data level names.
-        **kwargs: Keyword arguments for :func:`seaborn.catplot`.
+        **kwargs: Keyword arguments for :func:`seaborn.catplot` (e.g. ``col``, ``row``, ``col_wrap``).
 
     Returns:
         A :class:`seaborn.FacetGrid`.
@@ -75,8 +79,11 @@ def plot_run(
     Raises:
         ModuleNotFoundError: If Seaborn isn't installed.
         TypeError: For unknown `unit` arguments.
+        ValueError: For unknown `x`/`hue` arguments.
     """
-    params = CatplotParams.make(run_results, x=x, horizontal=horizontal, unit=unit, kind=kind, names=names, **kwargs)
+    params = CatplotParams.make(
+        run_results, x=x, hue=hue, horizontal=horizontal, unit=unit, kind=kind, names=names, **kwargs
+    )
     return plot_params(params)
 
 

--- a/src/rics/performance/_plot/_plot.py
+++ b/src/rics/performance/_plot/_plot.py
@@ -13,6 +13,8 @@ from ._postprocessors import make_postprocessors
 if TYPE_CHECKING:
     import seaborn
 
+    from ..plot_types import Aggregation
+
 
 def plot_run(
     run_results: ResultsDict | pd.DataFrame,
@@ -23,6 +25,8 @@ def plot_run(
     unit: Unit | None = None,
     kind: Kind = "bar",
     names: Iterable[str] = (),
+    relative_to: str | None = None,
+    agg: "Aggregation" = "min",
     **kwargs: Any,
 ) -> "seaborn.FacetGrid":
     """Create a :func:`seaborn.catplot` from run results.
@@ -67,10 +71,14 @@ def plot_run(
             to the complement of `hue` (or the higher-cardinality of candidate/data).
         hue: Hue quantity: ``'candidate'``, ``'data'``, or one of `names`. If omitted, defaults to the complement of `x`
             (or the candidate when `x` is a named dimension).
-        horizontal: If ``True``, plot timings on the X-axis instead. The `x` becomes the new Y-axis quantity.
-        unit: Y-axis time :attr:`~rics.performance.plot_types.Unit`.
+        horizontal: If ``True``, plot the metric on the X-axis instead. The `x` becomes the new Y-axis quantity.
+        unit: Y-axis time :attr:`~rics.performance.plot_types.Unit`. Not allowed in `relative_to` mode.
         kind: The :attr:`~rics.performance.plot_types.Kind` of plot to draw.
         names: Test data level names.
+        relative_to: If given, plot the speedup of each candidate relative to this baseline candidate (see
+            :func:`.relative_to`) instead of absolute timings. The Y-axis becomes a dimensionless ``speedup`` and a
+            reference line is drawn at ``1.0``.
+        agg: How to summarize the repeated timings in `relative_to` mode; one of ``'min'``, ``'median'``, ``'mean'``.
         **kwargs: Keyword arguments for :func:`seaborn.catplot` (e.g. ``col``, ``row``, ``col_wrap``).
 
     Returns:
@@ -79,10 +87,19 @@ def plot_run(
     Raises:
         ModuleNotFoundError: If Seaborn isn't installed.
         TypeError: For unknown `unit` arguments.
-        ValueError: For unknown `x`/`hue` arguments.
+        ValueError: For unknown `x`/`hue` arguments, or `unit` combined with `relative_to`.
     """
     params = CatplotParams.make(
-        run_results, x=x, hue=hue, horizontal=horizontal, unit=unit, kind=kind, names=names, **kwargs
+        run_results,
+        x=x,
+        hue=hue,
+        horizontal=horizontal,
+        unit=unit,
+        kind=kind,
+        names=names,
+        relative_to=relative_to,
+        agg=agg,
+        **kwargs,
     )
     return plot_params(params)
 
@@ -92,7 +109,7 @@ def plot_params(params: CatplotParams) -> "seaborn.axisgrid.FacetGrid":
     from seaborn import catplot
 
     kwargs = params.to_kwargs()
-    postprocessors = make_postprocessors(kwargs)
+    postprocessors = make_postprocessors(kwargs, params)
     facet_grid = catplot(**kwargs)
 
     logger = logging.getLogger(__package__).getChild("plot")

--- a/src/rics/performance/_plot/_plot.py
+++ b/src/rics/performance/_plot/_plot.py
@@ -77,7 +77,8 @@ def plot_run(
         names: Test data level names.
         relative_to: If given, plot the speedup of each candidate relative to this baseline candidate (see
             :func:`.relative_to`) instead of absolute timings. The Y-axis becomes a dimensionless ``speedup`` and a
-            reference line is drawn at ``1.0``.
+            reference line is drawn at ``1.0``. The baseline itself (always ``1.0``) is represented by the reference
+            line and omitted from the bars.
         agg: How to summarize the repeated timings in `relative_to` mode; one of ``'min'``, ``'median'``, ``'mean'``.
         **kwargs: Keyword arguments for :func:`seaborn.catplot` (e.g. ``col``, ``row``, ``col_wrap``).
 

--- a/src/rics/performance/_plot/_postprocessors.py
+++ b/src/rics/performance/_plot/_postprocessors.py
@@ -4,14 +4,17 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from seaborn import FacetGrid
 
+    from ._params import CatplotParams
+
 from rics.performance.plot_types import Postprocessor
 
 
-def make_postprocessors(kwargs: dict[str, Any]) -> list[Postprocessor]:
+def make_postprocessors(kwargs: dict[str, Any], params: "CatplotParams") -> list[Postprocessor]:
     """Construct postprocessors based on `kwargs`.
 
     Args:
         kwargs: Keyword arguments for :func:`seaborn.catplot`. May be modified.
+        params: The :class:`.CatplotParams` used to build `kwargs`.
 
     Returns:
         A list of postprocessors ``(FacetGrid) -> None``.
@@ -22,8 +25,10 @@ def make_postprocessors(kwargs: dict[str, Any]) -> list[Postprocessor]:
     if kind == "bar":
         # TODO(seaborn==0.13.2): log_scale makes bars vanish, so we do this instead.
         log_scale = kwargs.pop("log_scale", None)
-        horizontal = kwargs["x"].startswith("Time ")
-        postprocessors.append(BarPlotProcessor(bool(log_scale), horizontal))
+        postprocessors.append(BarPlotProcessor(bool(log_scale), params.horizontal))
+
+    if params.reference is not None:
+        postprocessors.append(ReferenceLineProcessor(params.reference, params.horizontal))
 
     return postprocessors
 
@@ -48,3 +53,16 @@ class BarPlotProcessor:
                     ax.set_xscale("log")
                 else:
                     ax.set_yscale("log")
+
+
+@dataclass(frozen=True)
+class ReferenceLineProcessor:
+    """Draw a guide line on the metric axis (e.g. ``speedup == 1`` in :func:`.relative_to` mode)."""
+
+    value: float
+    horizontal: bool
+
+    def __call__(self, facet_grid: "FacetGrid") -> None:
+        for ax in facet_grid.axes.flat:
+            line = ax.axvline if self.horizontal else ax.axhline
+            line(self.value, ls="--", lw=1, color="0.4", zorder=0)

--- a/src/rics/performance/_progress.py
+++ b/src/rics/performance/_progress.py
@@ -1,0 +1,102 @@
+"""Progress reporting for :class:`.MultiCaseTimer` runs.
+
+Uses ``tqdm`` for interactive (TTY) output, and falls back to periodic ``logging`` when output is not a terminal -- so
+captured/CI logs get readable progress lines instead of carriage-return spam (and ``tqdm`` becomes optional).
+"""
+
+import logging
+import sys
+import time
+from typing import Any, Protocol, TextIO
+
+
+class Progress(Protocol):
+    """Minimal progress-reporter interface."""
+
+    def set_description(self, desc: str) -> None:
+        """Set the text shown alongside progress."""
+
+    def update(self, n: int = 1) -> None:
+        """Advance progress by `n` steps."""
+
+    def close(self) -> None:
+        """Finalize the reporter."""
+
+
+class _NullProgress:
+    def set_description(self, desc: str) -> None: ...
+    def update(self, n: int = 1) -> None: ...
+    def close(self) -> None: ...
+
+
+class _TqdmProgress:
+    def __init__(self, total: int) -> None:
+        from tqdm.auto import tqdm
+
+        self._bar = tqdm(total=total)
+
+    def set_description(self, desc: str) -> None:
+        self._bar.set_description_str(desc, refresh=True)
+
+    def update(self, n: int = 1) -> None:
+        self._bar.update(n)
+
+    def close(self) -> None:
+        self._bar.close()
+
+
+class _LoggingProgress:
+    """Logs progress at most once per `min_interval` seconds (plus a final 100% line)."""
+
+    def __init__(
+        self,
+        total: int,
+        logger: logging.Logger | logging.LoggerAdapter[Any],
+        *,
+        min_interval: float = 1.0,
+    ) -> None:
+        self._total = total
+        self._logger = logger
+        self._min_interval = min_interval
+        self._n = 0
+        self._desc = ""
+        self._last = time.perf_counter()
+
+    def set_description(self, desc: str) -> None:
+        self._desc = desc
+
+    def update(self, n: int = 1) -> None:
+        self._n += n
+        now = time.perf_counter()
+        if self._n >= self._total or (now - self._last) >= self._min_interval:
+            self._last = now
+            pct = 100 * self._n / self._total if self._total else 100.0
+            suffix = f" {self._desc}" if self._desc else ""
+            self._logger.info("Progress: %d/%d (%.0f%%)%s", self._n, self._total, pct, suffix)
+
+    def close(self) -> None: ...
+
+
+def make_progress(
+    total: int,
+    *,
+    enabled: bool,
+    logger: logging.Logger | logging.LoggerAdapter[Any],
+    stream: TextIO | None = None,
+) -> Progress:
+    """Create a :class:`Progress` reporter.
+
+    Returns a no-op reporter when ``enabled=False``, a ``tqdm`` bar when `stream` is a TTY (and ``tqdm`` is installed),
+    and a logging-based reporter otherwise.
+    """
+    if not enabled:
+        return _NullProgress()
+
+    stream = stream if stream is not None else sys.stderr
+    if getattr(stream, "isatty", lambda: False)():
+        try:
+            return _TqdmProgress(total)
+        except ImportError:
+            logger.debug("tqdm not installed; falling back to logging-based progress.")
+
+    return _LoggingProgress(total, logger)

--- a/src/rics/performance/_util.py
+++ b/src/rics/performance/_util.py
@@ -9,13 +9,17 @@ from .plot_types import Aggregation
 from .types import ResultsDict
 
 
-def to_dataframe(run_results: ResultsDict, names: Iterable[str] = ()) -> pd.DataFrame:
+def to_dataframe(run_results: ResultsDict, names: Iterable[str] = (), *, tidy: bool = False) -> pd.DataFrame:
     """Create a DataFrame from performance run output, adding derived values.
 
     Args:
         run_results: A dict `run_results` on the form ``{candidate_label: {data_label: [runtime, ...]}}``, returned
             by :meth:`rics.performance.MultiCaseTimer.run`.
         names: Level names for tuple keys in the data (creates new columns). See :func:`.plot_run` for details.
+        tidy: If ``True``, return a minimal analysis-friendly frame with lowercase columns
+            ``['candidate', 'data', *names, 'run', 'seconds']`` and **no** presentation columns (unit conversions,
+            ``'Times min'`` etc.). The default (``False``) returns the plotting-oriented frame consumed by
+            :func:`.plot_run`, which mixes data with presentation (multiple ``'Time [<unit>]'`` columns).
 
     Returns:
         The `run_result` input as a DataFrame.
@@ -43,6 +47,11 @@ def to_dataframe(run_results: ResultsDict, names: Iterable[str] = ()) -> pd.Data
             frames.append(frame)
 
     df = pd.concat(frames, ignore_index=True)
+
+    if tidy:
+        renames = {"Candidate": "candidate", "Test data": "data", "Run no": "run", "Time [s]": "seconds"}
+        return df.rename(columns=renames)[["candidate", "data", *names, "run", "seconds"]]
+
     df["Time [ms]"] = df["Time [s]"] * 1000
     df["Time [μs]"] = df["Time [ms]"] * 1000
     df["Time [ns]"] = df["Time [μs]"] * 1000

--- a/src/rics/performance/_util.py
+++ b/src/rics/performance/_util.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from rics.types import verify_literal
 
+from .plot_types import Aggregation
 from .types import ResultsDict
 
 
@@ -51,6 +52,57 @@ def to_dataframe(run_results: ResultsDict, names: Iterable[str] = ()) -> pd.Data
     df["Times mean"] = df["Time [s]"] / df["Test data"].map(groupby.mean())
 
     return df
+
+
+def relative_to(
+    run_results: ResultsDict | pd.DataFrame,
+    baseline: str,
+    *,
+    names: Iterable[str] = (),
+    agg: Aggregation = "min",
+) -> pd.DataFrame:
+    """Compare candidates against a `baseline` candidate.
+
+    Reduces the repeated timings to one number per candidate/data pair (using `agg`) and expresses each candidate
+    relative to `baseline` on the same data.
+
+    Args:
+        run_results: Output of :meth:`.MultiCaseTimer.run` (or a :func:`.to_dataframe` frame).
+        baseline: Label of the candidate to compare against.
+        names: Level names for tuple keys in the data (creates new columns). See :func:`.plot_run` for details.
+        agg: How to summarize the repeated timings; one of ``'min'`` (default), ``'median'``, ``'mean'``.
+
+    Returns:
+        A tidy frame with columns ``['candidate', 'data', *names, 'seconds', 'baseline_seconds', 'speedup']`` where
+        ``speedup = baseline_seconds / seconds`` (``> 1`` means *faster* than the baseline). The geometric-mean speedup
+        per candidate is available in ``frame.attrs['geomean']``.
+
+    Raises:
+        KeyError: If `baseline` is not one of the candidate labels.
+        TypeError: If `agg` is not a valid aggregation.
+    """
+    import numpy as np
+
+    verify_literal(agg, Aggregation, name="agg")
+    names = tuple(names)
+    tidy = run_results.copy() if isinstance(run_results, pd.DataFrame) else to_dataframe(run_results, names=names)
+    if "Candidate" in tidy.columns:  # Convert a plotting-oriented frame to the tidy schema.
+        tidy = tidy.rename(columns={"Candidate": "candidate", "Test data": "data", "Time [s]": "seconds"})
+
+    group = ["candidate", "data", *names]
+    summary = tidy.groupby(group, observed=True)["seconds"].agg(agg).reset_index()
+
+    candidates = set(summary["candidate"])
+    if baseline not in candidates:
+        msg = f"Bad {baseline=}; not one of the candidate labels {sorted(candidates)}."
+        raise KeyError(msg)
+
+    base = summary[summary["candidate"] == baseline].set_index("data")["seconds"]
+    summary["baseline_seconds"] = summary["data"].map(base)
+    summary["speedup"] = summary["baseline_seconds"] / summary["seconds"]
+
+    summary.attrs["geomean"] = summary.groupby("candidate")["speedup"].agg(lambda s: np.exp(np.log(s).mean())).to_dict()
+    return summary
 
 
 def _has_names(data_label: Hashable, *, names: tuple[str, ...]) -> TypeGuard[tuple[str, ...]]:

--- a/src/rics/performance/_wrapper.py
+++ b/src/rics/performance/_wrapper.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pandas as pd
 
-from ._multi_case_timer import CandidateMethodArg, MultiCaseTimer, TestDataArg
+from ._multi_case_timer import CandidateMethodArg, MultiCaseTimer, SetupFunc, TestDataArg
 from ._util import to_dataframe
 from .types import DataFunc, DataType, Ts
 
@@ -19,6 +19,8 @@ def run_multivariate_test(
     show: bool = True,
     names: Iterable[str] | None = (),
     progress: bool = False,
+    setup: "SetupFunc[DataType] | None" = None,
+    warmup: int = 0,
     case_args: Collection[tuple[*Ts]] | None = None,
     kwargs: Any | None = None,
     **plot_kwargs: Any,
@@ -38,6 +40,9 @@ def run_multivariate_test(
         names: Level names for tuple keys in the data (creates new columns). See :func:`.plot_run` for details. Set to
             ``None`` to disable derived names when `test_data` is callable.
         progress: If ``True``, display a progress bar. Requires ``tqdm``.
+        setup: A callable ``(data) -> data`` run -- unmeasured -- before each timed repetition. See
+            :meth:`.MultiCaseTimer.run`.
+        warmup: Number of untimed calls per candidate/data pair before timing begins.
         case_args: These are positional arguments for the `test_data` callable.
         kwargs: Shared keyword arguments for the `test_data` callable.
         **plot_kwargs: See :func:`.plot_run` for details. Ignored if ``plot=False``.
@@ -62,7 +67,7 @@ def run_multivariate_test(
         case_args=case_args,
         kwargs=kwargs,
     )
-    run_results = timer.run(time_per_candidate=time_per_candidate, progress=progress)
+    run_results = timer.run(time_per_candidate=time_per_candidate, progress=progress, setup=setup, warmup=warmup)
 
     if names is None:
         names = ()

--- a/src/rics/performance/_wrapper.py
+++ b/src/rics/performance/_wrapper.py
@@ -39,7 +39,7 @@ def run_multivariate_test(
         show: If ``True``, attempt to display the figure. Ignored when ``plot=False``.
         names: Level names for tuple keys in the data (creates new columns). See :func:`.plot_run` for details. Set to
             ``None`` to disable derived names when `test_data` is callable.
-        progress: If ``True``, display a progress bar. Requires ``tqdm``.
+        progress: If ``True``, display progress (``tqdm`` on a TTY, periodic logging otherwise).
         setup: A callable ``(data) -> data`` run -- unmeasured -- before each timed repetition. See
             :meth:`.MultiCaseTimer.run`.
         warmup: Number of untimed calls per candidate/data pair before timing begins.

--- a/src/rics/performance/plot_types.py
+++ b/src/rics/performance/plot_types.py
@@ -18,6 +18,8 @@ Kind = _t.Literal["bar", "box", "boxen", "point", "strip", "swarm", "violin"]
 """Valid plot kinds."""
 Unit = _t.Literal["s", "ms", "μs", "us", "ns"]
 """Valid time units."""
+Aggregation = _t.Literal["min", "median", "mean"]
+"""How to summarize the repeated timings of a single candidate/data pair into one number."""
 
 Postprocessor = _Callable[["FacetGrid"], None]
 """A callable ``(FacetGrid) -> None`` which applies fixups to a :class:`seaborn.FacetGrid`."""

--- a/tests/performance/test_plot_module/test_plot.py
+++ b/tests/performance/test_plot_module/test_plot.py
@@ -72,6 +72,28 @@ def test_bad_x_raises(kind: Kind) -> None:
         plot_run(_GRID_RESULTS, kind=kind, x="nope", names=_GRID_NAMES)
 
 
+def test_relative_to(kind: Kind) -> None:
+    facet_grid = plot_run(_GRID_RESULTS, kind=kind, relative_to="baseline", names=_GRID_NAMES, col="source", x="rows")
+    # Speedup mode: the y-axis is the dimensionless 'speedup'.
+    assert facet_grid.axes.flat[0].get_ylabel() == "speedup"
+    # A reference line is drawn at 1.0 on every facet.
+    for ax in facet_grid.axes.flat:
+        ys = {tuple(line.get_ydata()) for line in ax.get_lines()}
+        assert (1.0, 1.0) in ys
+    plt.close(facet_grid.fig)
+
+
+def test_relative_to_horizontal(kind: Kind) -> None:
+    facet_grid = plot_run(_GRID_RESULTS, kind=kind, relative_to="baseline", names=_GRID_NAMES, horizontal=True)
+    assert facet_grid.axes.flat[0].get_xlabel() == "speedup"
+    plt.close(facet_grid.fig)
+
+
+def test_relative_to_rejects_unit(kind: Kind) -> None:
+    with pytest.raises(ValueError, match="dimensionless"):
+        plot_run(_GRID_RESULTS, kind=kind, relative_to="baseline", unit="ms")
+
+
 @cache
 def get_run_results() -> ResultsDict:
     with Path(__file__).parent.joinpath("run-results.json").open("r") as f:

--- a/tests/performance/test_plot_module/test_plot.py
+++ b/tests/performance/test_plot_module/test_plot.py
@@ -83,6 +83,15 @@ def test_relative_to(kind: Kind) -> None:
     plt.close(facet_grid.fig)
 
 
+def test_relative_to_excludes_baseline(kind: Kind) -> None:
+    # The baseline is the reference line; it must not appear as a (flat 1.0) bar/hue.
+    facet_grid = plot_run(_GRID_RESULTS, kind=kind, relative_to="baseline", names=_GRID_NAMES, hue="candidate")
+    legend_texts = {t.get_text() for t in facet_grid.legend.texts} if facet_grid.legend else set()
+    assert "baseline" not in legend_texts
+    assert "optimized" in legend_texts
+    plt.close(facet_grid.fig)
+
+
 def test_relative_to_horizontal(kind: Kind) -> None:
     facet_grid = plot_run(_GRID_RESULTS, kind=kind, relative_to="baseline", names=_GRID_NAMES, horizontal=True)
     assert facet_grid.axes.flat[0].get_xlabel() == "speedup"

--- a/tests/performance/test_plot_module/test_plot.py
+++ b/tests/performance/test_plot_module/test_plot.py
@@ -45,6 +45,33 @@ def test_estimator(kind: Kind, estimator: str) -> None:
     run(kind, estimator=estimator)
 
 
+_GRID_RESULTS: ResultsDict = {
+    "baseline": {("s100", 10): [1.0, 1.1], ("s100", 100): [1.2, 1.3], ("s1000", 10): [2.0, 2.1]},
+    "optimized": {("s100", 10): [0.5, 0.6], ("s100", 100): [0.6, 0.7], ("s1000", 10): [0.7, 0.8]},
+}
+_GRID_NAMES = ["source", "rows"]
+
+
+@pytest.mark.parametrize(
+    "x, hue",
+    [
+        ("rows", "candidate"),  # named dim on x, candidate as hue
+        ("candidate", "rows"),  # named dim as hue
+        ("data", None),  # default hue (candidate)
+        (None, "rows"),  # x auto-resolved
+        (None, None),  # full default
+    ],
+)
+def test_x_hue_from_named_dims(kind: Kind, x: str | None, hue: str | None) -> None:
+    facet_grid = plot_run(_GRID_RESULTS, kind=kind, x=x, hue=hue, names=_GRID_NAMES, col="source")
+    plt.close(facet_grid.fig)
+
+
+def test_bad_x_raises(kind: Kind) -> None:
+    with pytest.raises(ValueError, match="Bad x='nope'"):
+        plot_run(_GRID_RESULTS, kind=kind, x="nope", names=_GRID_NAMES)
+
+
 @cache
 def get_run_results() -> ResultsDict:
     with Path(__file__).parent.joinpath("run-results.json").open("r") as f:

--- a/tests/performance/test_progress.py
+++ b/tests/performance/test_progress.py
@@ -1,0 +1,42 @@
+import io
+import logging
+
+from rics.performance._progress import _LoggingProgress, _NullProgress, _TqdmProgress, make_progress
+
+LOGGER = logging.getLogger("test.performance.progress")
+
+
+class _Tty(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+class _NotTty(io.StringIO):
+    def isatty(self) -> bool:
+        return False
+
+
+def test_disabled_returns_null():
+    assert isinstance(make_progress(3, enabled=False, logger=LOGGER), _NullProgress)
+
+
+def test_non_tty_uses_logging():
+    progress = make_progress(3, enabled=True, logger=LOGGER, stream=_NotTty())
+    assert isinstance(progress, _LoggingProgress)
+
+
+def test_tty_uses_tqdm():
+    progress = make_progress(3, enabled=True, logger=LOGGER, stream=_Tty())
+    # tqdm is a test/dev dependency; if missing we fall back to logging, which is also acceptable.
+    assert isinstance(progress, (_TqdmProgress, _LoggingProgress))
+    progress.close()
+
+
+def test_logging_progress_emits_final_line(caplog):
+    progress = _LoggingProgress(2, LOGGER, min_interval=1e9)  # huge interval -> only the final (100%) line logs
+    progress.set_description("candidate(x)")
+    with caplog.at_level(logging.INFO, logger=LOGGER.name):
+        progress.update()
+        progress.update()
+    messages = [r.getMessage() for r in caplog.records]
+    assert messages == ["Progress: 2/2 (100%) candidate(x)"]

--- a/tests/performance/test_timer.py
+++ b/tests/performance/test_timer.py
@@ -6,6 +6,37 @@ from rics.performance import MultiCaseTimer, SkipIfParams
 
 
 @pytest.mark.filterwarnings("ignore:Results may be unreliable:UserWarning")
+def test_setup_runs_unmeasured_per_repeat():
+    setup_calls = {"n": 0}
+
+    def setup(data):
+        setup_calls["n"] += 1
+        return list(data)  # fresh copy each repetition
+
+    def candidate(lst):
+        lst.sort()  # mutates input; would be wrong without fresh data
+
+    repeat, number = 3, 2
+    MultiCaseTimer(candidate, test_data={"x": [3, 1, 2]}).run(repeat=repeat, number=number, setup=setup)
+
+    # timeit calls setup once per repeat (per timeit() call); autonumber is skipped because number= is fixed.
+    assert setup_calls["n"] == repeat
+
+
+@pytest.mark.filterwarnings("ignore:Results may be unreliable:UserWarning")
+def test_warmup_adds_untimed_calls():
+    calls = {"n": 0}
+
+    def candidate(_data):
+        calls["n"] += 1
+
+    repeat, number, warmup = 2, 3, 5
+    MultiCaseTimer(candidate, test_data={"x": 1}).run(repeat=repeat, number=number, warmup=warmup)
+
+    assert calls["n"] == warmup + repeat * number
+
+
+@pytest.mark.filterwarnings("ignore:Results may be unreliable:UserWarning")
 def test_skip():
     calls: dict[int, int] = defaultdict(int)
 

--- a/tests/performance/test_timer.py
+++ b/tests/performance/test_timer.py
@@ -21,3 +21,29 @@ def test_skip():
     assert [*run_results] == [label]
     assert [*run_results[label]] == ["1", "3"]
     assert calls == {1: 10, 3: 10}
+
+
+@pytest.mark.filterwarnings("ignore:Results may be unreliable:UserWarning")
+def test_skip_during_autonumber():
+    def func(data):
+        if data == "bad":
+            raise RuntimeError("must never be called for 'bad'")
+        return sum(range(50))
+
+    def skip_if(params: SkipIfParams[str]) -> bool:
+        return params.data == "bad"
+
+    run_results = MultiCaseTimer[str](func, test_data=["ok", "bad"]).run(time_per_candidate=0.01, skip_if=skip_if)
+
+    label = "test_skip_during_autonumber.<locals>.func"
+    assert [*run_results[label]] == ["ok"]
+
+
+def test_skip_all_variants_for_candidate(caplog):
+    # Every variant skipped -> no timing, no infinite loop in autonumber.
+    run_results = MultiCaseTimer[int](lambda data: data, test_data=[1, 2]).run(
+        time_per_candidate=0.01,
+        skip_if=lambda _: True,
+    )
+    assert not run_results
+    assert "Discarding candidate" in caplog.text

--- a/tests/performance/test_util.py
+++ b/tests/performance/test_util.py
@@ -1,6 +1,41 @@
 import pytest
 
-from rics.performance import format_perf_counter, format_seconds
+from rics.performance import format_perf_counter, format_seconds, relative_to, to_dataframe
+from rics.performance.types import ResultsDict
+
+RESULTS: ResultsDict = {
+    "baseline": {("g", 1): [1.0, 1.2], ("g", 2): [2.0, 2.4]},
+    "fast": {("g", 1): [0.5, 0.6], ("g", 2): [0.5, 0.7]},
+}
+
+
+class TestRelativeTo:
+    def test_speedup(self):
+        df = relative_to(RESULTS, baseline="baseline", names=["grp", "n"], agg="min")
+        fast = df[df["candidate"] == "fast"].set_index("n")
+        # baseline min: n1=1.0, n2=2.0 ; fast min: n1=0.5, n2=0.5
+        assert fast.loc[1, "speedup"] == pytest.approx(2.0)
+        assert fast.loc[2, "speedup"] == pytest.approx(4.0)
+        base = df[df["candidate"] == "baseline"]
+        assert (base["speedup"] == 1.0).all()
+
+    def test_geomean_attr(self):
+        df = relative_to(RESULTS, baseline="baseline", names=["grp", "n"])
+        assert df.attrs["geomean"]["fast"] == pytest.approx((2.0 * 4.0) ** 0.5)
+        assert df.attrs["geomean"]["baseline"] == pytest.approx(1.0)
+
+    def test_accepts_dataframe(self):
+        frame = to_dataframe(RESULTS, names=["grp", "n"])
+        df = relative_to(frame, baseline="baseline", names=["grp", "n"])
+        assert df[df["candidate"] == "fast"]["speedup"].min() == pytest.approx(2.0)
+
+    def test_bad_baseline(self):
+        with pytest.raises(KeyError, match="nope"):
+            relative_to(RESULTS, baseline="nope", names=["grp", "n"])
+
+    def test_bad_agg(self):
+        with pytest.raises(TypeError, match="agg"):
+            relative_to(RESULTS, baseline="baseline", agg="p99")  # type: ignore[arg-type]
 
 
 class TestDeprecated:

--- a/tests/performance/test_util.py
+++ b/tests/performance/test_util.py
@@ -9,6 +9,20 @@ RESULTS: ResultsDict = {
 }
 
 
+class TestToDataFrameTidy:
+    def test_columns(self):
+        df = to_dataframe(RESULTS, names=["grp", "n"], tidy=True)
+        assert list(df.columns) == ["candidate", "data", "grp", "n", "run", "seconds"]
+        # No presentation/derived columns.
+        assert not [c for c in df.columns if c.startswith("Time [")]
+
+    def test_values(self):
+        df = to_dataframe(RESULTS, names=["grp", "n"], tidy=True)
+        row = df[(df["candidate"] == "fast") & (df["n"] == 1) & (df["run"] == 0)].iloc[0]
+        assert row["seconds"] == 0.5
+        assert row["grp"] == "g"
+
+
 class TestRelativeTo:
     def test_speedup(self):
         df = relative_to(RESULTS, baseline="baseline", names=["grp", "n"], agg="min")

--- a/tests/performance/test_wrapper.py
+++ b/tests/performance/test_wrapper.py
@@ -13,7 +13,7 @@ def unload_modules():
         del sys.modules[key]
 
 
-def get_raw_timings(_self, func, test_data, repeat, _number, /):
+def get_raw_timings(_self, func, test_data, repeat, _number, /, **_):
     return [func.sleep_multiplier * test_data] * repeat
 
 


### PR DESCRIPTION
## Summary

Ergonomics improvements to `rics.performance`, split into atomic commits (one per CHANGELOG bullet). Each commit carries its source change, docstrings, CHANGELOG entry, and tests.

### Added
- **`MultiCaseTimer.run(setup=, warmup=)`** — `setup` is a `(data) -> data` callable run unmeasured before each timed repetition (mirroring `timeit`); `warmup` runs untimed calls before timing. Resolves #398.
- **`relative_to()`** — compare candidates against a baseline (per-pair speedup table + geometric mean).
- **`to_dataframe(tidy=True)`** — minimal analysis frame (`candidate`/`data`/`*names`/`run`/`seconds`) without presentation columns.
- **`plot_run(relative_to=<baseline>)`** — plot per-candidate speedup against a baseline (dimensionless y-axis, reference line at `1.0`); the baseline is shown as the reference line and omitted from the bars.

### Changed
- **`plot_run()` `hue` arg + named dims** — accepts an explicit `hue`; both `x` and `hue` may reference a test-data dimension `name` (not just `'candidate'`/`'data'`), e.g. `plot_run(..., x='rows', hue='candidate', col='source')`.
- **Progress logging fallback** — `run(progress=True)` falls back to periodic `logging` when output is not a TTY, making `tqdm` optional in non-interactive runs.
- **Clarified `run()` time-budget docstring** — total runtime is `repeat * time_per_candidate * n_candidates`, independent of the number of test-data variants.

Also includes a fix: `MultiCaseTimer.run()` now calls `skip_if` during the autonumber phase.

## Test plan
- `uv run pytest tests/performance -q` → 63 passed
- `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` clean on touched paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
